### PR TITLE
[Feat] 성실도 관련 기능 구현

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
@@ -1,9 +1,6 @@
 package devkor.ontime_back.controller;
 
-import devkor.ontime_back.dto.LatenessHistoryResponse;
-import devkor.ontime_back.dto.PunctualityPageResponse;
-import devkor.ontime_back.dto.ScheduleHistoryResponse;
-import devkor.ontime_back.dto.UpdatePunctualityScoreDto;
+import devkor.ontime_back.dto.*;
 import devkor.ontime_back.service.ScheduleService;
 import devkor.ontime_back.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -38,15 +35,16 @@ public class UserController {
         return ResponseEntity.ok("성실도 점수가 초기화 되었습니다!");
     }
 
-    // 성실도 점수 업데이트(약속 준비과정 종료시 request)
-    @PutMapping("/{userId}/update-punctuality")
-    public ResponseEntity<String> updatePunctualityScore(
+    // 약속 준비 종료 이후 지각시간(Schedule 테이블), 성실도 점수(User 테이블) 업데이트
+    @PutMapping("/{userId}/finish-preparation")
+    public ResponseEntity<String> finishPreparation(
             @PathVariable Long userId,
-            @RequestBody UpdatePunctualityScoreDto updatePunctualityScoreDto) {
+            @RequestBody FinishPreparationDto finishPreparationDto) {
 
-        userService.updatePunctualityScore(userId, updatePunctualityScoreDto.getLatenessTime());
+        scheduleService.updateLatenessTime(finishPreparationDto);
+        userService.updatePunctualityScore(userId, finishPreparationDto.getLatenessTime());
 
-        return ResponseEntity.ok("성실도 점수가 성공적으로 업데이트 되었습니다!");
+        return ResponseEntity.ok("해당 약속의 지각시간과 해당 유저의 성실도점수가 성공적으로 업데이트 되었습니다!");
     }
 }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/FinishPreparationDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/FinishPreparationDto.java
@@ -1,0 +1,11 @@
+package devkor.ontime_back.dto;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class FinishPreparationDto {
+    private UUID scheduleId;
+    private Integer latenessTime;
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/Schedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/Schedule.java
@@ -1,10 +1,7 @@
 package devkor.ontime_back.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.sql.Time;
 import java.time.LocalDateTime;
@@ -41,6 +38,7 @@ public class Schedule {
 
     private Time scheduleSpareTime; // 스케줄 별 여유시간
 
+    @Setter
     private Integer latenessTime; // 지각 시간 (NULL이면 약속 전, 0이면 약속 성공, N(양수)면 N분 지각)
 
     @Lob // 대용량 텍스트 필드

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -189,6 +189,18 @@ public class ScheduleService {
                 .toList();
     }
 
+    // 지각 시간 업데이트
+    public void updateLatenessTime(FinishPreparationDto finishPreparationDto) {
+        UUID scheduleId = finishPreparationDto.getScheduleId();
+        Integer latenessTime = finishPreparationDto.getLatenessTime();
+
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("Schedule with ID " + scheduleId + " not found."));
+
+        schedule.setLatenessTime(latenessTime);
+        scheduleRepository.save(schedule);
+    }
+
     private ScheduleDto mapToDto(Schedule schedule) {
         return new ScheduleDto(
                 schedule.getScheduleId(),

--- a/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
@@ -40,6 +40,9 @@ public class UserAuthService {
                 .password(userSignUpDto.getPassword())
                 .name(userSignUpDto.getName())
                 .role(Role.USER)
+                .punctualityScore((float)-1)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
                 .build();
 
         // 비밀번호 암호화 후 저장


### PR DESCRIPTION
1. feat::약속 준비 종료 이후 관련값 업데이트 기능 구현
   - PUT /user/{userId}/finish-preparation
   - 클라이언트에서 약속이 종료됐을 때 본 API 호출
   - 지각시간(Schedule테이블)과 성실도점수(User테이블)가 업데이트됨.
     
2. feat:: 유저 회원가입시 성실도 관련 속성 초기화
   - 회원가입시 성실도점수는 -1, 초기화이후약속수는 0, 초기화이후지각수는 0으로 초기화되게 만듦(기존에는 전부 NULL로 초기화 돼서 성실도 점수 업데이트하는 과정에서 오류 발생했음.)