### PR TITLE
[mod] 사용자 알림 미허용 시 약속알림 가지 않도록 스케줄러 로직 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/repository/UserRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/UserRepository.java
@@ -4,10 +4,12 @@ import devkor.ontime_back.entity.User;
 import devkor.ontime_back.entity.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/UserSettingRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/UserSettingRepository.java
@@ -2,10 +2,12 @@ package devkor.ontime_back.repository;
 
 import devkor.ontime_back.entity.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.UUID;
 
+@Repository
 public interface UserSettingRepository extends JpaRepository<UserSetting, UUID> {
     Optional<UserSetting> findByUserId(Long userId);
 }


### PR DESCRIPTION
약속알림 스케줄러의 서비스 레이어에서 알림 보내기 전에
약속을 바탕으로 사용자 조회를 조회하고, 사용자를 바탕으로 사용자 세팅을 조회해
알림 허용여부를 확인한 뒤 알림 보내도록 로직 수정함.