### PR TITLE
[mod] 약속 준비 종료 이후 속성 업데이트 API 트랜잭션 처리

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationController.java
@@ -1,0 +1,58 @@
+package devkor.ontime_back.controller;
+
+import devkor.ontime_back.dto.FinishPreparationDto;
+import devkor.ontime_back.service.PreparationService;
+import devkor.ontime_back.service.ScheduleService;
+import devkor.ontime_back.service.UserAuthService;
+import devkor.ontime_back.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/preparation")
+@RequiredArgsConstructor
+public class PreparationController {
+    private final UserAuthService userAuthService;
+    private final ScheduleService scheduleService;
+    private final UserService userService;
+    private final PreparationService preparationService;
+
+    @Operation(
+            summary = "약속 준비 종료 이후 지각시간, 성실도점수 업데이트 (약속 준비 종료 이후 호출해야함)",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "성실도 점수 초기화 요청 JSON 데이터",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{\"scheduleId\": \"a304cde3-8ee9-4054-971a-300aacc2189a\", \"latenessTime\": 3}"
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "지각시간, 성실도점수 업데이트 성공", content = @Content(mediaType = "application/json", schema = @Schema(example = "해당 약속의 지각시간과 해당 유저의 성실도점수가 성공적으로 업데이트 되었습니다!"))),
+            @ApiResponse(responseCode = "4XX", description = "지각시간, 성실도점수 업데이트 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
+    })
+    @PutMapping("/finish") // 약속 준비 종료 이후 지각시간(Schedule 테이블), 성실도 점수(User 테이블) 업데이트
+    public ResponseEntity<String> finishPreparation(
+            HttpServletRequest request,
+            @RequestBody FinishPreparationDto finishPreparationDto) {
+
+        Long userId = userAuthService.getUserIdFromToken(request);
+
+        preparationService.finishPreparation(userId, finishPreparationDto);
+
+        return ResponseEntity.ok("해당 약속의 지각시간과 해당 유저의 성실도점수가 성공적으로 업데이트 되었습니다!");
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
@@ -79,34 +79,5 @@ public class UserController {
         return ResponseEntity.ok("성실도 점수가 초기화 되었습니다!");
     }
 
-    @Operation(
-            summary = "약속 준비 종료 이후 지각시간, 성실도점수 업데이트 (약속 준비 종료 이후 호출해야함)",
-            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "성실도 점수 초기화 요청 JSON 데이터",
-                    required = true,
-                    content = @Content(
-                            schema = @Schema(
-                                    type = "object",
-                                    example = "{\"scheduleId\": \"a304cde3-8ee9-4054-971a-300aacc2189a\", \"latenessTime\": 3}"
-                            )
-                    )
-            )
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "지각시간, 성실도점수 업데이트 성공", content = @Content(mediaType = "application/json", schema = @Schema(example = "해당 약속의 지각시간과 해당 유저의 성실도점수가 성공적으로 업데이트 되었습니다!"))),
-            @ApiResponse(responseCode = "4XX", description = "지각시간, 성실도점수 업데이트 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
-    })
-    @PutMapping("/finish-preparation") // 약속 준비 종료 이후 지각시간(Schedule 테이블), 성실도 점수(User 테이블) 업데이트
-    public ResponseEntity<String> finishPreparation(
-            HttpServletRequest request,
-            @RequestBody FinishPreparationDto finishPreparationDto) {
-
-        Long userId = userAuthService.getUserIdFromToken(request);
-
-        scheduleService.updateLatenessTime(finishPreparationDto);
-        userService.updatePunctualityScore(userId, finishPreparationDto.getLatenessTime());
-
-        return ResponseEntity.ok("해당 약속의 지각시간과 해당 유저의 성실도점수가 성공적으로 업데이트 되었습니다!");
-    }
 }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/service/PreparationService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/PreparationService.java
@@ -1,0 +1,20 @@
+package devkor.ontime_back.service;
+
+import devkor.ontime_back.dto.FinishPreparationDto;
+import devkor.ontime_back.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PreparationService {
+    private final UserService userService;
+    private final ScheduleService scheduleService;
+
+    @Transactional
+    public void finishPreparation(Long userId, FinishPreparationDto finishPreparationDto) {
+        scheduleService.updateLatenessTime(finishPreparationDto);
+        userService.updatePunctualityScore(userId, finishPreparationDto.getLatenessTime());
+    }
+}


### PR DESCRIPTION
- 약속 종료 이후 지각시간, 성실도 점수 초기화 이후 약속 수, 성실도 점수 초기화 이후 지각 수, 성실도 점수가 반드시 모두 업데이트 되어야 데이터 정합성이 지켜져 트랜잭션 처리하였음.
- 기존 약속 준비 종료 이후 속성 업데이트하는 API는 컨트롤러에서 지각시간 업데이트, 성실도 점수 업데이트하는 메서드를 서비스 계층에서 각각 호출함
- 컨트롤러에서 서비스 계층의 하나의 메서드만 호출하게 만들어 서비스 계층에서 해당 메서드 트랙잭션 처리하도록 로직 수정
- PreparationController로 API를 따로 뺐음.(기존엔 UserController에 있었음)
- PreparationService에 finishPreparation 메서드 정의해서 트랜잭션 처리해두었음.
