### PR TITLE
[test] UserAuthController 테스트코드 작성 완료

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/dto/ChangePasswordDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/ChangePasswordDto.java
@@ -1,11 +1,17 @@
 package devkor.ontime_back.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class ChangePasswordDto {
     private String currentPassword;
     private String newPassword;
+
+    @Builder
+    public ChangePasswordDto(String currentPassword, String newPassword) {
+        this.currentPassword = currentPassword;
+        this.newPassword = newPassword;
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserAdditionalInfoDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserAdditionalInfoDto.java
@@ -1,15 +1,17 @@
 package devkor.ontime_back.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.sql.Time;
 
-@AllArgsConstructor
 @Getter
 public class UserAdditionalInfoDto {
     private Integer spareTime;  // 여유시간
     private String note;     // 주의사항
+
+    @Builder
+    public UserAdditionalInfoDto(Integer spareTime, String note) {
+        this.spareTime = spareTime;
+        this.note = note;
+    }
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
@@ -1,22 +1,12 @@
 package devkor.ontime_back;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import devkor.ontime_back.config.SecurityConfig;
 import devkor.ontime_back.controller.UserAuthController;
 import devkor.ontime_back.repository.UserRepository;
-import devkor.ontime_back.repository.UserSettingRepository;
 import devkor.ontime_back.service.UserAuthService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.reactive.PathRequest;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
@@ -32,9 +22,6 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected UserAuthService userAuthService;
-
-    @MockBean
-    protected UserSettingRepository userSettingRepository;
 
     @MockBean
     protected UserRepository userRepository;

--- a/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
@@ -2,11 +2,13 @@ package devkor.ontime_back;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import devkor.ontime_back.controller.UserAuthController;
+import devkor.ontime_back.global.generallogin.handler.LoginSuccessHandler;
 import devkor.ontime_back.repository.UserRepository;
 import devkor.ontime_back.service.UserAuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
@@ -25,5 +27,11 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected UserRepository userRepository;
+
+    @MockBean
+    protected AuthenticationManager authenticationManager;
+
+    @MockBean
+    protected LoginSuccessHandler loginSuccessHandler;
 
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/TestSecurityConfig.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/TestSecurityConfig.java
@@ -12,8 +12,8 @@ public class TestSecurityConfig {
     public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("login/success", "/sign-up", "/*/additional-info").permitAll()
-                        .anyRequest().authenticated());
+                        //.requestMatchers("/login", "login/success", "/sign-up", "/*/additional-info").permitAll()
+                        .anyRequest().permitAll());
 
         return http.build();
     }

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
@@ -56,6 +56,7 @@ class UserAuthControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.message").value("회원가입이 성공적으로 완료되었습니다. 추가 정보를 기입해주세요( {userId}/additional-info )"));
+                .andExpect(jsonPath("$.message").value("회원가입이 성공적으로 완료되었습니다. 추가 정보를 기입해주세요( {userId}/additional-info )"))
+                .andExpect(jsonPath("$.data.userId").value(1));
      }
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
@@ -3,6 +3,8 @@ package devkor.ontime_back.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import devkor.ontime_back.ControllerTestSupport;
 import devkor.ontime_back.TestSecurityConfig;
+import devkor.ontime_back.dto.ChangePasswordDto;
+import devkor.ontime_back.dto.UserAdditionalInfoDto;
 import devkor.ontime_back.dto.UserSignUpDto;
 import devkor.ontime_back.entity.Role;
 import devkor.ontime_back.entity.User;
@@ -10,17 +12,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import(TestSecurityConfig.class)
 class UserAuthControllerTest extends ControllerTestSupport {
@@ -59,4 +67,74 @@ class UserAuthControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("회원가입이 성공적으로 완료되었습니다. 추가 정보를 기입해주세요( {userId}/additional-info )"))
                 .andExpect(jsonPath("$.data.userId").value(1));
      }
+
+     @DisplayName("(회원가입 직후) 추가 정보 기입에 성공한다")
+     @Test
+     void addInfo() throws Exception {
+         // given
+         UserAdditionalInfoDto userAdditionalInfoDto = UserAdditionalInfoDto.builder()
+                 .spareTime(10)
+                 .note("내 인생에 더 이상의 지각은 없다!!!")
+                 .build();
+
+         // 원래 addInfo는 User객체를 반환하지만 컨트롤러에서는 반환값을 사용하지 않으므로 null로 설정하였음.
+         when(userAuthService.addInfo(any(Long.class), any(UserAdditionalInfoDto.class))).thenReturn(null);
+
+         // when // then
+         mockMvc.perform(
+                        put("/1/additional-info")
+                                .content(objectMapper.writeValueAsString(userAdditionalInfoDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("추가 정보가 성공적으로 기입되었습니다!"));
+      }
+
+    @DisplayName("비밀번호 변경에 성공한다")
+    @Test
+    void changePassword() throws Exception {
+        // given
+        ChangePasswordDto changePasswordDto = ChangePasswordDto.builder()
+                .currentPassword("password1234")
+                .newPassword("password12345")
+                .build();
+
+        // 원래 changePassword는 User객체를 반환하지만 컨트롤러에서는 반환값을 사용하지 않으므로 null로 설정하였음.
+        when(userAuthService.changePassword(any(Long.class), any(ChangePasswordDto.class))).thenReturn(null);
+
+        // when // then
+        mockMvc.perform(
+                        put("/change-password")
+                                .content(objectMapper.writeValueAsString(changePasswordDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("비밀번호가 성공적으로 변경되었습니다!"));
+    }
+
+    @DisplayName("계정 삭제에 성공한다")
+    @Test
+    void deleteUser() throws Exception {
+        // given
+        // 원래 changePassword는 삭제된 유저의 Id를 반환하지만 컨트롤러에서는 반환값을 사용하지 않으므로 null로 설정하였음.
+        when(userAuthService.deleteUser(any(Long.class))).thenReturn(null);
+
+        // when // then
+        mockMvc.perform(
+                        delete("/user/delete")
+                                .content("{}")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("계정이 성공적으로 삭제되었습니다!"));
+    }
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/global/generallogin/filter/CustomJsonUsernamePasswordAuthenticationFilterTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/global/generallogin/filter/CustomJsonUsernamePasswordAuthenticationFilterTest.java
@@ -1,0 +1,68 @@
+package devkor.ontime_back.global.generallogin.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+class CustomJsonUsernamePasswordAuthenticationFilterTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private CustomJsonUsernamePasswordAuthenticationFilter filter;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("필터가 올바른 인증 요청을 처리한다")
+    void testFilterProcessesCorrectRequest() throws Exception {
+        // given
+        String email = "user@example.com";
+        String password = "password123";
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/json");
+        request.setMethod("POST");
+        request.setRequestURI("/login");
+        request.setContent(objectMapper.writeValueAsBytes(Map.of("email", email, "password", password)));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        UsernamePasswordAuthenticationToken authRequest =
+                new UsernamePasswordAuthenticationToken(email, password);
+
+        when(authenticationManager.authenticate(authRequest))
+                .thenReturn(new UsernamePasswordAuthenticationToken(email, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        filter.setAuthenticationManager(authenticationManager);
+
+        // when
+        Authentication result = filter.attemptAuthentication(request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getPrincipal()).isEqualTo(email);
+    }
+}

--- a/ontime-back/src/test/java/devkor/ontime_back/service/UserAuthServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/UserAuthServiceTest.java
@@ -1,18 +1,20 @@
 package devkor.ontime_back.service;
 
+import devkor.ontime_back.dto.ChangePasswordDto;
+import devkor.ontime_back.dto.UserAdditionalInfoDto;
 import devkor.ontime_back.dto.UserSignUpDto;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.entity.UserSetting;
 import devkor.ontime_back.repository.UserRepository;
 import devkor.ontime_back.repository.UserSettingRepository;
 import devkor.ontime_back.response.GeneralException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Collection;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -113,6 +115,170 @@ class UserAuthServiceTest {
                 .isInstanceOf(GeneralException.class)
                 .hasMessage("이미 존재하는 userSettingId 입니다.");
     }
+
+    @DisplayName("(회원가입 직후) 유저의 추가정보 기입에 성공한다")
+    @Test
+    void addInfo() throws Exception {
+        // given(유저데이터 하드저장 및 추가 기입 DTO 생성)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password("password1234")
+                .name("junbeom")
+                .build();
+        userRepository.save(addedUser);
+
+        UserAdditionalInfoDto userAdditionalInfoDto = UserAdditionalInfoDto.builder()
+                .spareTime(10)
+                .note("내 인생에 이제 지각은 없다!!!")
+                .build();
+
+        // when(추가정보 기입)
+        User additionalInfoAddedUser = userAuthService.addInfo(addedUser.getId(), userAdditionalInfoDto);
+
+        // then
+        assertThat(additionalInfoAddedUser.getId()).isNotNull();
+        assertThat(additionalInfoAddedUser.getId()).isEqualTo(addedUser.getId());
+        assertThat(additionalInfoAddedUser)
+                .extracting("spareTime", "note")
+                .contains(10, "내 인생에 이제 지각은 없다!!!");
+    }
+
+    @DisplayName("존재하지 않는 유저의 추가정보를 기입하는 경우 예외가 발생한다")
+    @Test
+    void addInfoWithWrongUser() throws Exception {
+        // given(유저데이터 하드저장 및 추가 기입 DTO 생성)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password("password1234")
+                .name("junbeom")
+                .build();
+        userRepository.save(addedUser);
+
+        UserAdditionalInfoDto userAdditionalInfoDto = UserAdditionalInfoDto.builder()
+                .spareTime(10)
+                .note("내 인생에 이제 지각은 없다!!!")
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> userAuthService.addInfo(2L, userAdditionalInfoDto))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 유저 id입니다.");
+    }
+
+    @DisplayName("비밀번호 변경에 성공한다")
+    @Test
+    void changePassword(){
+        // given(유저 데이터 하드저장 및 비밀번호 변경 DTO 생성)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .build();
+        userRepository.save(addedUser);
+
+        ChangePasswordDto changePasswordDto = ChangePasswordDto.builder()
+                .currentPassword("password1234")
+                .newPassword("password12345")
+                .build();
+
+        // when
+        User passwordChangedUser = userAuthService.changePassword(addedUser.getId(), changePasswordDto);
+
+        // then
+        assertThat(passwordChangedUser.getId()).isNotNull();
+        assertThat(passwordChangedUser.getId()).isEqualTo(addedUser.getId());
+        assertThat(passwordEncoder.matches("password12345", passwordChangedUser.getPassword())).isTrue();
+     }
+
+    @DisplayName("비밀번호 변경 시 존재하지 않는 유저를 인자로 넘기는 경우 예외가 발생한다.")
+    @Test
+    void changePasswordWithWrongUser(){
+        // given(유저 데이터 하드저장 및 비밀번호 변경 DTO 생성)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .build();
+        userRepository.save(addedUser);
+
+        ChangePasswordDto changePasswordDto = ChangePasswordDto.builder()
+                .currentPassword("password1234")
+                .newPassword("password12345")
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> userAuthService.changePassword(2L, changePasswordDto))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 유저 id입니다.");
+    }
+
+    @DisplayName("비밀번호 변경시 현재 비밀번호를 잘못 입력한 경우 예외가 발생한다.")
+    @Test
+    void changePasswordWithWrongCurrentPassword(){
+        // given(유저 데이터 하드저장 및 비밀번호 변경 DTO 생성)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .build();
+        userRepository.save(addedUser);
+
+        ChangePasswordDto changePasswordDto = ChangePasswordDto.builder()
+                .currentPassword("password123")
+                .newPassword("password12345")
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> userAuthService.changePassword(addedUser.getId(), changePasswordDto))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage("기존 비밀번호가 틀렸습니다.");
+    }
+
+    @DisplayName("비밀번호 변경시 새 비밀번호를 현재 비밀번호와 같게 입력한 경우 예외가 발생한다.")
+    @Test
+    void changePasswordWithSamePassword(){
+        // given(유저 데이터 하드저장 및 비밀번호 변경 DTO 생성)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .build();
+        userRepository.save(addedUser);
+
+        ChangePasswordDto changePasswordDto = ChangePasswordDto.builder()
+                .currentPassword("password1234")
+                .newPassword("password1234")
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> userAuthService.changePassword(addedUser.getId(), changePasswordDto))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage("새 비밀번호와 기존 비밀번호가 일치합니다.");
+    }
+
+    @DisplayName("계정 삭제에 성공한다")
+    @Test
+    void deleteUser(){
+        // given(유저 데이터 하드저장 및 검증을 위해 해당 유저 아이디 tagerUserId에 저장)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .build();
+        userRepository.save(addedUser);
+
+        Long targetUserId = addedUser.getId();
+
+        // when
+        Long deletedUserId = userAuthService.deleteUser(addedUser.getId());
+
+        // then
+        assertThat(deletedUserId).isNotNull();
+        assertThat(deletedUserId).isEqualTo(targetUserId);
+        assertThat(userRepository.findById(targetUserId)).isEmpty();
+    }
+
+
 
     private UserSignUpDto getUserSignUpDto(String email, String password, String name, String userSettingId) {
         UserSignUpDto userSignUpDto = UserSignUpDto.builder()


### PR DESCRIPTION
### 작성한 코드
- 추가정보 기입 API 컨트롤러, 서비스 계층 테스트코드 작성 완료
- 비밀번호 변경 API 컨트롤러, 서비스 계층 테스트코드 작성 완료
- 계정 삭제 API 컨트롤러, 서비스 계층 테스트코드 작성 완료

### 일반로그인 테스트 코드는 없음
- 일반로그인 테스트는 설계 및 작성 비용이 많이 들어 패스하였음. 
  로그인은 수동테스트 하여야함.

### 확인해야할 사항
- 모든 API에 대한 비인증 테스트를 위해 TestSecurityConfig파일을 테스트
  디렉토리에 만들었고, 인증부분에 permitAll()코드를 삽입해 jwt인증
  없이도 API요청이 가능케 하였음.
- 테스트 코드를 작성하는 와중에 프로덕션 코드의 리팩토링도 진행하였음
  (트랜잭션으로 인한 성능 감소를 방지하기 위해 UserAuthService 클래스의 상단에 @transaction(readOnly = True)를 걸고
  내부에 CUD작업이 필요한 메소드에 @transaction을 추가로 걸었음.)