### PR TITLE
[test] 사용자 관련 코드(UserController, UserService) 테스트 작성 완료

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
         Long userId = userAuthService.getUserIdFromToken(request);
         float punctualityScore = userService.getPunctualityScore(userId); // -1 or float 0~100 반환
 
-        String message = "-1이면 성실도 점수 초기화 직후의 상태. 0~100의 float면 성실도 점수";
+        String message = "-1이면 성실도점수 초기화 직후의 상태. 0~100의 float 자료형이면 성실도 점수";
         return ResponseEntity.ok(ApiResponseForm.success(new PunctualityScoreResponse(punctualityScore), message));
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateSpareTimeDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateSpareTimeDto.java
@@ -1,8 +1,16 @@
 package devkor.ontime_back.dto;
 
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class UpdateSpareTimeDto {
     private Integer newSpareTime;
+
+    @Builder
+    public UpdateSpareTimeDto(Integer newSpareTime) {
+        this.newSpareTime = newSpareTime;
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
@@ -36,12 +36,10 @@ public class User {
     @Column(columnDefinition = "TEXT") // 명시적으로 TEXT 타입으로 정의
     private String note; // 주의사항
 
-    @Setter
     private Float punctualityScore; // 성실도 점수
 
-    @Setter
     private Integer scheduleCountAfterReset; // 성실도 점수 초기화 이후 약속 개수
-    @Setter
+
     private Integer latenessCountAfterReset; // 성실도 점수 초기화 이후 지각한 약속 개수
 
     @Enumerated(EnumType.STRING)
@@ -101,10 +99,24 @@ public class User {
     }
 
     //여유 시간 업데이트
-    public void updateSpareTime(Integer newSpareTime) { this.spareTime = newSpareTime; }
+    public void setSpareTime(Integer newSpareTime) { this.spareTime = newSpareTime; }
 
     //유저세팅과 연결
     public void setUserSetting(UserSetting userSetting) {
         this.userSetting = userSetting;
+    }
+
+    // 약속 수 초기화 및 설정
+    public void setScheduleCountAfterReset(Integer scheduleCount) {
+        this.scheduleCountAfterReset = scheduleCount;
+    }
+
+    // 지각 수 초기화 및 설정
+    public void setLatenessCountAfterReset(Integer latenessCount) {
+        this.latenessCountAfterReset = latenessCount;
+    }
+
+    public void setPunctualityScore(float punctualityScore) {
+        this.punctualityScore = punctualityScore;
     }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/UserService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/UserService.java
@@ -5,9 +5,11 @@ import devkor.ontime_back.entity.User;
 import devkor.ontime_back.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;
@@ -15,21 +17,26 @@ public class UserService {
     // 성실도 점수 반환
     public Float getPunctualityScore(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 id입니다."))
                 .getPunctualityScore();
     }
 
     // 성실도 점수 초기화
-    public void resetPunctualityScore(Long userId) {
+    @Transactional
+    public Float resetPunctualityScore(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 id입니다."));
         user.resetPunctualityScore(); // 점수 초기화
         userRepository.save(user);
+
+        return user.getPunctualityScore();
     }
 
-    public void updatePunctualityScore(Long userId, Integer latenessTime) {
+    // 성실도 점수 업데이트
+    @Transactional
+    public User updatePunctualityScore(Long userId, Integer latenessTime) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 id입니다."));
 
         if (user.getPunctualityScore() == (float) -1) {
             // 초기화 이후 첫 약속
@@ -50,14 +57,20 @@ public class UserService {
 
         user.setPunctualityScore(punctualityScore);
         userRepository.save(user);
+
+        return user;
     }
 
-    public void updateSpareTime(Long userId, UpdateSpareTimeDto updateSpareTimeDto) {
+    // 여유시간 업데이트
+    @Transactional
+    public User updateSpareTime(Long userId, UpdateSpareTimeDto updateSpareTimeDto) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 id입니다."));
 
-        user.updateSpareTime(updateSpareTimeDto.getNewSpareTime());
+        user.setSpareTime(updateSpareTimeDto.getNewSpareTime());
 
         userRepository.save(user);
+
+        return user;
     }
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
@@ -2,9 +2,12 @@ package devkor.ontime_back;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import devkor.ontime_back.controller.UserAuthController;
+import devkor.ontime_back.controller.UserController;
 import devkor.ontime_back.global.generallogin.handler.LoginSuccessHandler;
 import devkor.ontime_back.repository.UserRepository;
+import devkor.ontime_back.service.ScheduleService;
 import devkor.ontime_back.service.UserAuthService;
+import devkor.ontime_back.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -12,7 +15,10 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
-        controllers = UserAuthController.class
+        controllers = {
+                UserAuthController.class,
+                UserController.class
+        }
 )
 public abstract class ControllerTestSupport {
 
@@ -26,6 +32,9 @@ public abstract class ControllerTestSupport {
     protected UserAuthService userAuthService;
 
     @MockBean
+    protected UserService userService;
+
+    @MockBean
     protected UserRepository userRepository;
 
     @MockBean
@@ -33,5 +42,8 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected LoginSuccessHandler loginSuccessHandler;
+
+    @MockBean
+    protected ScheduleService scheduleService;
 
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
@@ -102,6 +102,7 @@ class UserAuthControllerTest extends ControllerTestSupport {
                 .newPassword("password12345")
                 .build();
 
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
         // 원래 changePassword는 User객체를 반환하지만 컨트롤러에서는 반환값을 사용하지 않으므로 null로 설정하였음.
         when(userAuthService.changePassword(any(Long.class), any(ChangePasswordDto.class))).thenReturn(null);
 
@@ -122,8 +123,8 @@ class UserAuthControllerTest extends ControllerTestSupport {
     @Test
     void deleteUser() throws Exception {
         // given
-        // 원래 changePassword는 삭제된 유저의 Id를 반환하지만 컨트롤러에서는 반환값을 사용하지 않으므로 null로 설정하였음.
-        when(userAuthService.deleteUser(any(Long.class))).thenReturn(null);
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        when(userAuthService.deleteUser(any(Long.class))).thenReturn(1L);
 
         // when // then
         mockMvc.perform(

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/UserControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/UserControllerTest.java
@@ -1,0 +1,93 @@
+package devkor.ontime_back.controller;
+
+import devkor.ontime_back.ControllerTestSupport;
+import devkor.ontime_back.TestSecurityConfig;
+import devkor.ontime_back.dto.ChangePasswordDto;
+import devkor.ontime_back.dto.UpdateSpareTimeDto;
+import devkor.ontime_back.dto.UserSignUpDto;
+import devkor.ontime_back.entity.Role;
+import devkor.ontime_back.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestSecurityConfig.class)
+class UserControllerTest extends ControllerTestSupport {
+
+    @DisplayName("성실도 점수 조회에 성공한다.")
+    @Test
+    void getPunctualityScore() throws Exception {
+        // given
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        when(userService.getPunctualityScore(any(Long.class))).thenReturn(99.999f);
+
+        // when // then
+        mockMvc.perform(
+                        get("/user/punctuality-score")
+                                .content("{}")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("-1이면 성실도점수 초기화 직후의 상태. 0~100의 float 자료형이면 성실도 점수"))
+                .andExpect(jsonPath("$.data.punctualityScore").value(99.999f));
+    }
+
+    @DisplayName("성실도 점수 초기회에 성공한다.")
+    @Test
+    void resetPunctualityScore() throws Exception {
+        // given
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        when(userService.resetPunctualityScore(any(Long.class))).thenReturn(-1f);
+
+        // when // then
+        mockMvc.perform(
+                        put("/user/reset-punctuality")
+                                .content("{}")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("성실도 점수가 성공적으로 초기화 되었습니다! (초기화 이후 약속 수 <- 0, 초기화 이후 지각 수 <- 0, 성실도 점수 <- -1)"));
+    }
+
+    @DisplayName("여유시간 업데이트에 성공한다.")
+    @Test
+    void updateSpareTime() throws Exception {
+        // given
+        UpdateSpareTimeDto updateSpareTimeDto = UpdateSpareTimeDto.builder().newSpareTime(10).build();
+
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        // 원래 updateSpareTime는 User객체를 반환하지만 컨트롤러에서는 반환값을 사용하지 않으므로 null로 설정하였음.
+        when(userService.updateSpareTime(any(Long.class), any(UpdateSpareTimeDto.class))).thenReturn(null);
+
+        // when // then
+        mockMvc.perform(
+                        put("/user/spare-time")
+                                .content(objectMapper.writeValueAsString(updateSpareTimeDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("사용자 여유시간이 성공적으로 업데이트되었습니다!"));
+    }
+
+}

--- a/ontime-back/src/test/java/devkor/ontime_back/service/UserAuthServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/UserAuthServiceTest.java
@@ -56,8 +56,8 @@ class UserAuthServiceTest {
         // then
         assertThat(addedUser.getId()).isNotNull();
         assertThat(addedUser)
-                .extracting("email", "name")
-                .contains("user@example.com", "junbeom");
+                .extracting("email", "name", "punctualityScore", "scheduleCountAfterReset", "latenessCountAfterReset")
+                .contains("user@example.com", "junbeom", -1f, 0, 0);
         assertThat(passwordEncoder.matches("password1234", addedUser.getPassword())).isTrue();
         assertThat(userSetting).isNotNull();
         assertThat(userSetting.getUserSettingId())
@@ -190,9 +190,9 @@ class UserAuthServiceTest {
         assertThat(passwordEncoder.matches("password12345", passwordChangedUser.getPassword())).isTrue();
      }
 
-    @DisplayName("비밀번호 변경 시 존재하지 않는 유저를 인자로 넘기는 경우 예외가 발생한다.")
+    @DisplayName("비밀번호 변경 시 존재하지 않는 유저id를 인자로 넘기는 경우 예외가 발생한다.")
     @Test
-    void changePasswordWithWrongUser(){
+    void changePasswordWithWrongUserId(){
         // given(유저 데이터 하드저장 및 비밀번호 변경 DTO 생성)
         User addedUser = User.builder()
                 .email("user@example.com")

--- a/ontime-back/src/test/java/devkor/ontime_back/service/UserServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/UserServiceTest.java
@@ -1,0 +1,315 @@
+package devkor.ontime_back.service;
+
+import devkor.ontime_back.dto.UpdateSpareTimeDto;
+import devkor.ontime_back.entity.User;
+import devkor.ontime_back.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("성실도 점수 조회에 성공한다")
+    @Test
+    void getPunctualityScore(){
+        // given(유저 데이터 하드저장 및 성실도 점수 조회를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(0.1f)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId();
+
+        // when
+        Float punctualityScore = userService.getPunctualityScore(targetId);
+
+        // then
+        assertThat(punctualityScore).isEqualTo(0.1f);
+
+     }
+
+    @DisplayName("성실도 점수를 조회할 때 존재하지 않는 유저id를 인자로 넘기는 경우 예외가 발생한다")
+    @Test
+    void getPunctualityScoreWithWrongUserId(){
+        // given(유저 데이터 하드저장 및 성실도 점수 조회를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(0.1f)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId() +1;
+
+         // when // then
+         assertThatThrownBy(() -> userService.getPunctualityScore(targetId))
+                 .isInstanceOf(IllegalArgumentException.class)
+                 .hasMessage("존재하지 않는 유저 id입니다.");
+
+    }
+
+
+    @DisplayName("성실도 점수 초기화에 성공한다")
+    @Test
+    void resetPunctualityScore(){
+        // given(유저 데이터 하드저장 및 성실도 점수 초기화를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(0.1f)
+                .scheduleCountAfterReset(2)
+                .latenessCountAfterReset(1)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId();
+
+        // when
+        Float punctualityScore = userService.resetPunctualityScore(targetId);
+
+        // then
+        User foundUser = userRepository.findById(targetId).orElseThrow(() -> new IllegalArgumentException());
+        assertThat(punctualityScore).isEqualTo(-1f);
+        assertThat(foundUser.getScheduleCountAfterReset()).isEqualTo(0);
+        assertThat(foundUser.getLatenessCountAfterReset()).isEqualTo(0);
+    }
+
+    @DisplayName("성실도 점수를 초기화할 때 존재하지 않는 유저id를 인자로 넘기는 경우 예외가 발생한다")
+    @Test
+    void resetPunctualityScoreWithWrongUserId(){
+        // given(유저 데이터 하드저장 및 성실도 점수 조회를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(0.1f)
+                .scheduleCountAfterReset(1)
+                .latenessCountAfterReset(1)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId() +1;
+
+        // when // then
+        assertThatThrownBy(() -> userService.resetPunctualityScore(targetId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 유저 id입니다.");
+
+    }
+
+
+    @DisplayName("1. 성실도 점수 초기화(회원가입 포함) 직후 " +
+            "2. 약속에 지각 하지 않았을 때 " +
+            "성실도 점수 업데이트에 성공한다." +
+            "(준비 종료 이후 /schedul/finish 엔드포인트에 의해 호출되는 메서드)")
+    @Test
+    void updatePunctualityFirstWithoutLateness(){
+        // given(유저 데이터 하드저장 및 성실도 점수 업데이트를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId();
+
+        // when
+        User updatedUser = userService.updatePunctualityScore(targetId, 0);
+
+        // then
+        assertThat(updatedUser.getId()).isNotNull();
+        assertThat(updatedUser.getId()).isEqualTo(addedUser.getId());
+        assertThat(updatedUser)
+                .extracting("punctualityScore", "scheduleCountAfterReset", "latenessCountAfterReset")
+                .contains(calculatePunctualityScore(1, 0), 1, 0);
+    }
+
+    @DisplayName("1. 성실도 점수 초기화(회원가입 포함) 직후 " +
+            "2. 약속에 지각 했을 때 " +
+            "성실도 점수 업데이트에 성공한다." +
+            "(준비 종료 이후 /schedul/finish 엔드포인트에 의해 호출되는 메서드)")
+    @Test
+    void updatePunctualityFirstWithLateness(){
+        // given(유저 데이터 하드저장 및 성실도 점수 업데이트를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId();
+
+        // when
+        User updatedUser = userService.updatePunctualityScore(targetId, 1);
+
+        // then
+        assertThat(updatedUser.getId()).isNotNull();
+        assertThat(updatedUser.getId()).isEqualTo(addedUser.getId());
+        assertThat(updatedUser)
+                .extracting("punctualityScore", "scheduleCountAfterReset", "latenessCountAfterReset")
+                .contains(calculatePunctualityScore(1, 1), 1, 1);
+    }
+
+    @DisplayName("1. 기존 성실도 점수가 있을 때(초기화 값이 아닐 때) " +
+            "2. 약속에 지각 하지 않았을 때 " +
+            "성실도 점수 업데이트에 성공한다." +
+            "(준비 종료 이후 /schedul/finish 엔드포인트에 의해 호출되는 메서드)")
+    @Test
+    void updatePunctualityNotFirstWithoutLateness(){
+        // given(유저 데이터 하드저장 및 성실도 점수 업데이트를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(calculatePunctualityScore(3, 1))
+                .scheduleCountAfterReset(3)
+                .latenessCountAfterReset(1)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId();
+
+        // when
+        User updatedUser = userService.updatePunctualityScore(targetId, 0);
+
+        // then
+        assertThat(updatedUser.getId()).isNotNull();
+        assertThat(updatedUser.getId()).isEqualTo(addedUser.getId());
+        assertThat(updatedUser)
+                .extracting("punctualityScore", "scheduleCountAfterReset", "latenessCountAfterReset")
+                .contains(calculatePunctualityScore(4, 1), 4, 1);
+    }
+
+    @DisplayName("1. 기존 성실도 점수가 있을 때(초기화 값이 아닐 때) " +
+            "2. 약속에 지각 했을 때 " +
+            "성실도 점수 업데이트에 성공한다." +
+            "(준비 종료 이후 /schedul/finish 엔드포인트에 의해 호출되는 메서드)")
+    @Test
+    void updatePunctualityNotFirstWithLateness(){
+        // given(유저 데이터 하드저장 및 성실도 점수 업데이트를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(calculatePunctualityScore(3, 1))
+                .scheduleCountAfterReset(3)
+                .latenessCountAfterReset(1)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId();
+
+        // when
+        User updatedUser = userService.updatePunctualityScore(targetId, 1);
+
+        // then
+        assertThat(updatedUser.getId()).isNotNull();
+        assertThat(updatedUser.getId()).isEqualTo(addedUser.getId());
+        assertThat(updatedUser)
+                .extracting("punctualityScore", "scheduleCountAfterReset", "latenessCountAfterReset")
+                .contains(calculatePunctualityScore(4, 2), 4, 2);
+    }
+
+    @DisplayName("성실도 점수 업데이트할 때 존재하지 않는 유저id를 인자로 넘기는 경우 예외가 발생한다.")
+    @Test
+    void updatePunctualityWithWrongUserId(){
+        // given(유저 데이터 하드저장 및 성실도 점수 업데이트를 위한 targetId 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(calculatePunctualityScore(3, 1))
+                .scheduleCountAfterReset(3)
+                .latenessCountAfterReset(1)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId() + 1;
+
+        // when // then
+        assertThatThrownBy(() -> userService.updatePunctualityScore(targetId, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 유저 id입니다.");
+    }
+
+
+    @DisplayName("여유시간 업데이트에 성공한다")
+    @Test
+    void updateSpareTime(){
+        // given(유저 데이터 하드저장 및 여유시간 업데이트를 위한 targetId 설정 및 updateSpareTimeDto 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .spareTime(10)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId();
+
+        UpdateSpareTimeDto updateSpareTimeDto = UpdateSpareTimeDto.builder().newSpareTime(20).build();
+
+        // when
+        User updatedUser = userService.updateSpareTime(targetId, updateSpareTimeDto);
+
+        // then
+        assertThat(updatedUser.getId()).isNotNull();
+        assertThat(updatedUser.getId()).isEqualTo(addedUser.getId());
+        assertThat(updatedUser.getSpareTime()).isEqualTo(20);
+    }
+
+    @DisplayName("여유시간 업데이트할 때 존재하지 않는 유저id를 인자로 넘기는 경우 예외가 발생한다.")
+    @Test
+    void updateSpareTimeWithWrongUserId(){
+        // given(유저 데이터 하드저장 및 여유시간 업데이트를 위한 targetId 설정 및 updateSpareTimeDto 설정)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .spareTime(10)
+                .build();
+        userRepository.save(addedUser);
+        Long targetId = addedUser.getId() +1;
+
+        UpdateSpareTimeDto updateSpareTimeDto = UpdateSpareTimeDto.builder().newSpareTime(20).build();
+
+        // when // then
+        assertThatThrownBy(() -> userService.updateSpareTime(targetId, updateSpareTimeDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 유저 id입니다.");
+    }
+
+
+    float calculatePunctualityScore(int totalSchedules, int lateSchedules){
+        return (1 - ((float) lateSchedules / totalSchedules)) * 100;
+    }
+
+}


### PR DESCRIPTION
## 작성한 코드
- **성실도점수 조회 API** 컨트롤러, 서비스 계층 테스트코드 작성 완료
- **성실도점수 초기화 API** 컨트롤러, 서비스 계층 테스트코드 작성 완료
- **성실도점수 업데이트 API** 컨트롤러, 서비스 계층 테스트코드 작성 완료
- **여유시간 업데이트 API** 컨트롤러, 서비스 계층 테스트코드 작성 완료

## 확인해야할 사항
- 테스트 코드를 작성하는 도중 **프로덕션 코드의 리팩토링**도 진행하였음
  (유저 엔티티의 PunctualityScore, ScheduleCountAfterReset, LatenessCountAfterRest의 
  **@Setter 제거**하고 Set메서드를 엔티티 안에 만듦)

## 코드를 작성하며 학습한 내용
#### 영속성 컨텍스트 ####
- **테스트코드에서 빌더패턴으로 하드저장한 객체**는 **영속성 컨텍스트**에 들어가지 않으므로 테스트코드에서 해당 객체의 값의 변경을 확인하고 싶으면 findbyId등의 메서드를 통해 **영속성 컨텍스트에서 관리되는 객체의 복사본**으로 값의 변경을 확인해야한다. 
(하드저장한 객체에서 getId() 등을 하면 업데이트된 값이 아니라 기존 하드 저장한 값이 반환됨.)
#### 동시성 문제 ####
- 테스트코드 예외발생시 userId = 2L로 하드코딩하니까 **동시성문제** 발생했음. 한 메서드만 독립적으로 수행했을 때 id가 2L인 데이터는 없어야하는데 실제로 클래스 단위로 테스트를 수행하니 id가 2L인 데이터가 존재하는 문제가 발생했음. **클래스의 각 테스트메서드가 병렬로 실행되다보니 생긴 문제**로 보임. (userId = 100L로 설정하니까 다 동작했음)
아마 teardown말고 @Transaction을 사용하면 이 문제가 방지될 것으로 보임. (실제로 확인해보지는 않음. 지피티로만 맞는 말인지 검증함)
(+ 결국 teardown을 계속 쓰면서 2L로 하드코딩하는 대신 addedUser.getId() + 1로 병렬로 실행돼도 Id가 겹치지 않게 userId를 할당하여 문제를 해결하였음)
