### PR TITLE
[test] 스케줄 API 中 조준범(깃허브Id: JunbeomKoreaUniv)이 작성한 테스트코드 작성 완료

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/ScheduleController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/ScheduleController.java
@@ -4,6 +4,7 @@ import devkor.ontime_back.dto.*;
 import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.response.ApiResponseForm;
 import devkor.ontime_back.service.ScheduleService;
+import devkor.ontime_back.service.UserAuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -26,6 +27,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ScheduleController {
     private final ScheduleService scheduleService;
+    private final UserAuthService userAuthService;
 
 
     // 오늘의 약속 조회
@@ -221,8 +223,8 @@ public class ScheduleController {
             @ApiResponse(responseCode = "4XX", description = "지각 히스토리 조회 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(토큰 오류 제외 비즈니스 로직 오류는 없음)")))
     })
     @GetMapping("/lateness-history") // 지각 히스토리 조회
-    public ResponseEntity<ApiResponseForm<List<LatenessHistoryResponse>>> getPunctualityPage(HttpServletRequest request) {
-        Long userId = scheduleService.getUserIdFromToken(request);
+    public ResponseEntity<ApiResponseForm<List<LatenessHistoryResponse>>> getLatenessHistory(HttpServletRequest request) {
+        Long userId = userAuthService.getUserIdFromToken(request);
         List<LatenessHistoryResponse> latenessHistory = scheduleService.getLatenessHistory(userId);
 
         String message = "지각 히스토리 조회 성공!";
@@ -286,7 +288,7 @@ public class ScheduleController {
             HttpServletRequest request,
             @RequestBody FinishPreparationDto finishPreparationDto) {
 
-        Long userId = scheduleService.getUserIdFromToken(request);
+        Long userId = userAuthService.getUserIdFromToken(request);
 
         scheduleService.finishSchedule(userId, finishPreparationDto);
 

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/FinishPreparationDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/FinishPreparationDto.java
@@ -1,5 +1,6 @@
 package devkor.ontime_back.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.UUID;
@@ -8,4 +9,10 @@ import java.util.UUID;
 public class FinishPreparationDto {
     private UUID scheduleId;
     private Integer latenessTime;
+
+    @Builder
+    public FinishPreparationDto(UUID scheduleId, Integer latenessTime) {
+        this.scheduleId = scheduleId;
+        this.latenessTime = latenessTime;
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -9,7 +9,7 @@ import devkor.ontime_back.repository.*;
 import devkor.ontime_back.response.ErrorCode;
 import devkor.ontime_back.response.GeneralException;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ScheduleService {
 
@@ -78,6 +78,7 @@ public class ScheduleService {
     }
 
     // 약속 삭제
+    @Transactional
     public void deleteSchedule(UUID scheduleId, Long userId) {
         Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new EntityNotFoundException("Schedule with ID " + scheduleId + " not found."));
         // schedule을 만든 userId인지 확인
@@ -88,6 +89,7 @@ public class ScheduleService {
     }
 
     // 약속 수정
+    @Transactional
     public void modifySchedule(Long userId, ScheduleModDto scheduleModDto) {
         // schedule 확인
         Schedule schedule = scheduleRepository.findById(scheduleModDto.getScheduleId()).orElseThrow(() -> new EntityNotFoundException("Schedule with ID " + scheduleModDto.getScheduleId() + " not found."));
@@ -114,6 +116,7 @@ public class ScheduleService {
     }
 
     // 약속 추가
+    @Transactional
     public void addSchedule(ScheduleAddDto scheduleAddDto, Long userId) {
         // user 확인
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("User with ID " + userId + " not found."));
@@ -145,6 +148,7 @@ public class ScheduleService {
     }
 
     // 버튼 누름
+    @Transactional
     public void checkIsStarted(UUID scheduleId, Long userId) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new EntityNotFoundException("Schedule with ID " + scheduleId + " not found."));
@@ -170,6 +174,7 @@ public class ScheduleService {
     }
 
     // 지각 시간 업데이트
+    @Transactional
     public void updateLatenessTime(FinishPreparationDto finishPreparationDto) {
         UUID scheduleId = finishPreparationDto.getScheduleId();
         Integer latenessTime = finishPreparationDto.getLatenessTime();

--- a/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
@@ -1,6 +1,7 @@
 package devkor.ontime_back;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import devkor.ontime_back.controller.ScheduleController;
 import devkor.ontime_back.controller.UserAuthController;
 import devkor.ontime_back.controller.UserController;
 import devkor.ontime_back.global.generallogin.handler.LoginSuccessHandler;
@@ -17,7 +18,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(
         controllers = {
                 UserAuthController.class,
-                UserController.class
+                UserController.class,
+                ScheduleController.class
         }
 )
 public abstract class ControllerTestSupport {

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/ScheduleControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/ScheduleControllerTest.java
@@ -1,0 +1,83 @@
+package devkor.ontime_back.controller;
+
+import devkor.ontime_back.ControllerTestSupport;
+import devkor.ontime_back.TestSecurityConfig;
+import devkor.ontime_back.dto.FinishPreparationDto;
+import devkor.ontime_back.dto.LatenessHistoryResponse;
+import devkor.ontime_back.dto.UpdateSpareTimeDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestSecurityConfig.class)
+class ScheduleControllerTest extends ControllerTestSupport {
+
+    @DisplayName("지각 히스토리 조회에 성공한다.")
+    @Test
+    void getLatenessHistory() throws Exception {
+        // given
+        List<LatenessHistoryResponse> latenessHistory = new ArrayList<>();
+        latenessHistory.add(new LatenessHistoryResponse(
+                UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"),
+                "을사년 새해",
+                LocalDateTime.of(2025, 1, 1, 0, 0),
+                1
+        ));
+
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        when(scheduleService.getLatenessHistory(any(Long.class))).thenReturn(latenessHistory);
+
+        // when // then
+        mockMvc.perform(
+                        get("/schedule/lateness-history")
+                                .content("")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("지각 히스토리 조회 성공!"))
+                .andExpect(jsonPath("$.data[0].scheduleId").value("3fa85f64-5717-4562-b3fc-2c963f66afe5"));
+    }
+
+    @DisplayName("약속 종료(성실도점수/지각시간 업데이트)에 성공한다.")
+    @Test
+    void finishSchedule() throws Exception {
+        // given
+        FinishPreparationDto finishPreparationDto = FinishPreparationDto.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .build();
+
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        doNothing().when(scheduleService).finishSchedule(any(Long.class), any(FinishPreparationDto.class));
+
+        // when // then
+        mockMvc.perform(
+                        put("/schedule/finish")
+                                .content(objectMapper.writeValueAsString(finishPreparationDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("지각시간과 성실도점수가 성공적으로 업데이트 되었습니다!"));
+    }
+}

--- a/ontime-back/src/test/java/devkor/ontime_back/service/ScheduleServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/ScheduleServiceTest.java
@@ -1,0 +1,277 @@
+package devkor.ontime_back.service;
+
+import devkor.ontime_back.dto.FinishPreparationDto;
+import devkor.ontime_back.dto.LatenessHistoryResponse;
+import devkor.ontime_back.entity.Schedule;
+import devkor.ontime_back.entity.User;
+import devkor.ontime_back.repository.ScheduleRepository;
+import devkor.ontime_back.repository.UserRepository;
+import devkor.ontime_back.response.GeneralException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest
+class ScheduleServiceTest {
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @AfterEach
+    void tearDown() {
+        scheduleRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("지각 히스토리 조회에 성공한다")
+    @Test
+    void getLatenessHistory(){
+        // given(유저, 스케줄1,2,3 데이터 하드저장)
+        //      (비즈니스 로직에 따르면 스케줄 추가되면 지각시간은 -1로 자동으로 초기화됨.)
+        //      (                      이후 스케줄이 종료되면 지각시간이 0 or 양수로 업데이트됨.)
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+
+        Schedule addedSchedule1 = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .scheduleName("을사년 새해")
+                .scheduleTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .latenessTime(3)
+                .user(addedUser)
+                .build();
+
+        Schedule addedSchedule2 = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe6"))
+                .scheduleName("생일파티")
+                .scheduleTime(LocalDateTime.of(2025, 1, 12, 21, 0))
+                .latenessTime(1)
+                .user(addedUser)
+                .build();
+
+        Schedule addedSchedule3 = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe7"))
+                .scheduleName("Ontime 출시일")
+                .scheduleTime(LocalDateTime.of(2025, 2, 14, 00, 0))
+                .latenessTime(-1)
+                .user(addedUser)
+                .build();
+
+        scheduleRepository.save(addedSchedule1);
+        scheduleRepository.save(addedSchedule2);
+        scheduleRepository.save(addedSchedule3);
+
+        // when
+        List<LatenessHistoryResponse> latenessHistory = scheduleService.getLatenessHistory(addedUser.getId());
+
+        // then
+        assertThat(latenessHistory).hasSize(2)
+                .extracting("scheduleId", "scheduleName", "scheduleTime", "latenessTime")
+                .containsExactlyInAnyOrder(
+                        tuple(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"), "을사년 새해", LocalDateTime.of(2025, 1, 1, 0, 0), 3),
+                        tuple(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe6"), "생일파티", LocalDateTime.of(2025, 1, 12, 21, 0), 1)
+                );
+    }
+
+    @DisplayName("지각 시간 업데이트에 성공한다.")
+    @Test
+    void updateLatenessTime(){
+        // given
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+
+        Schedule addedSchedule = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .scheduleName("을사년 새해")
+                .scheduleTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .latenessTime(-1)
+                .user(addedUser)
+                .build();
+        scheduleRepository.save(addedSchedule);
+
+        FinishPreparationDto finishPreparationDto = FinishPreparationDto.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .latenessTime(1)
+                .build();
+
+        // when
+        scheduleService.updateLatenessTime(finishPreparationDto);
+
+        // then
+        assertThat(scheduleRepository.findById(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .get().getLatenessTime()).isEqualTo(1);
+    }
+
+    @DisplayName("지각 시간 업데이트할 때, 잘못된 schedulId를 DTO에 담아 요청하는 경우 예외가 발생한다.")
+    @Test
+    void updateLatenessTimeWithWrongScheduleId(){
+        // given
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+
+        Schedule addedSchedule = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .scheduleName("을사년 새해")
+                .scheduleTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .latenessTime(-1)
+                .user(addedUser)
+                .build();
+        scheduleRepository.save(addedSchedule);
+
+        FinishPreparationDto finishPreparationDto = FinishPreparationDto.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe6"))
+                .latenessTime(1)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> scheduleService.updateLatenessTime(finishPreparationDto))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage("해당 약속이 존재하지 않습니다.");
+    }
+
+    @DisplayName("약속을 종료해 지각시간과 성실도점수 업데이트에 성공한다.")
+    @Test
+    void finishSchedule(){
+        // given
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+
+        Schedule addedSchedule = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .scheduleName("을사년 새해")
+                .scheduleTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .latenessTime(-1)
+                .user(addedUser)
+                .build();
+        scheduleRepository.save(addedSchedule);
+
+        FinishPreparationDto finishPreparationDto = FinishPreparationDto.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .latenessTime(1)
+                .build();
+
+        // when
+        scheduleService.finishSchedule(addedUser.getId(), finishPreparationDto);
+
+        // then
+        assertThat(scheduleRepository.findById(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .get().getLatenessTime()).isEqualTo(1);
+        assertThat(userRepository.findById(addedUser.getId()).get().getPunctualityScore()).isEqualTo(0f);
+    }
+
+    @DisplayName("약속을 종료할 때, 잘못된 유저id를 인자로 넘기는 경우 예외가 발생한다.")
+    @Test
+    void finishScheduleWithWrongUserId(){
+        // given
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+
+        Schedule addedSchedule = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .scheduleName("을사년 새해")
+                .scheduleTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .latenessTime(-1)
+                .user(addedUser)
+                .build();
+        scheduleRepository.save(addedSchedule);
+
+        FinishPreparationDto finishPreparationDto = FinishPreparationDto.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .latenessTime(1)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> scheduleService.finishSchedule(addedUser.getId() + 1, finishPreparationDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 유저 id입니다.");
+    }
+
+    @DisplayName("약속을 종료할 때, 잘못된 scheduleId를 인자로 넘기는 경우 예외가 발생한다.")
+    @Test
+    void finishScheduleWithWrongScheduleId(){
+        // given
+        User addedUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("junbeom")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(addedUser);
+
+        Schedule addedSchedule = Schedule.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe5"))
+                .scheduleName("을사년 새해")
+                .scheduleTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .latenessTime(-1)
+                .user(addedUser)
+                .build();
+        scheduleRepository.save(addedSchedule);
+
+        FinishPreparationDto finishPreparationDto = FinishPreparationDto.builder()
+                .scheduleId(UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afe6"))
+                .latenessTime(1)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> scheduleService.finishSchedule(addedUser.getId(), finishPreparationDto))
+                .isInstanceOf(GeneralException.class)
+                .hasMessage("해당 약속이 존재하지 않습니다.");
+    }
+
+
+}


### PR DESCRIPTION
## 작성한 코드
- **지각 히스토리 조회 API** 컨트롤러, 서비스 계층 테스트코드 작성 완료
- **약속 종료(성실도점수/지각시간 업데이트) API** 컨트롤러, 서비스 계층 테스트코드 작성 완료

## 확인해야할 사항
- 테스트 코드를 작성하는 도중 **프로덕션 코드의 리팩토링**도 진행하였음
  (수정 전: 스케줄 서비스 클래스에 @Transactional이 걸려있었음.
   수정 후: 스케줄 서비스 클래스에 @Transactional(readOnly = true)를 걸고 CUD가 필요한 메서드에 @Transactional을 걸어주었음.)  

## 전체 테스트 결과
[Test Results — ontime-back [test].pdf](https://github.com/user-attachments/files/18507280/Test.Results.ontime-back.test.pdf)

