### PR TITLE
[feat] TDD개발방식으로 친구추가 관련 API들 컨트롤러 계층 코드 및 테스트 코드 작성 완료, Swagger 명세 완료

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/FriendShipController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/FriendShipController.java
@@ -1,0 +1,78 @@
+package devkor.ontime_back.controller;
+
+import devkor.ontime_back.dto.FriendDto;
+import devkor.ontime_back.dto.GetFriendshipRequesterResponse;
+import devkor.ontime_back.dto.UpdateAcceptStatusDto;
+import devkor.ontime_back.entity.User;
+import devkor.ontime_back.entity.GetFriendListResponse;
+import devkor.ontime_back.response.ApiResponseForm;
+import devkor.ontime_back.service.FriendshipService;
+import devkor.ontime_back.service.UserAuthService;
+import devkor.ontime_back.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/friends")
+public class FriendShipController {
+
+    private final UserAuthService userAuthService;
+    private final UserService userService;
+    private final FriendshipService friendShipService;
+
+    @PostMapping("/link/create") // 친구 추가 링크 생성
+    public ResponseEntity<ApiResponseForm<String>> createFriendShipLink(HttpServletRequest request) {
+        Long userId = userAuthService.getUserIdFromToken(request);
+
+        String friendShipUUID =friendShipService.createFriendShipLink(userId);
+
+        String message = "친구추가 링크 생성 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음.";
+        return ResponseEntity.ok(ApiResponseForm.success(friendShipUUID, message));
+    }
+
+    @GetMapping("/add-requester/{uuid}") // 친구 추가 요청자 조회
+    public ResponseEntity<ApiResponseForm<GetFriendshipRequesterResponse>> getFriendShipRequester(HttpServletRequest request, @PathVariable String uuid) {
+        Long userId = userAuthService.getUserIdFromToken(request);
+
+        User requester = friendShipService.getFriendShipRequester(userId, UUID.fromString(uuid));
+        GetFriendshipRequesterResponse getFriendshipRequesterResponse = GetFriendshipRequesterResponse.builder()
+                .requesterId(requester.getId())
+                .requesterName(requester.getName())
+                .requesterEmail(requester.getEmail())
+                .build();
+
+        String message = "친구추가 요청자 조회 성공. 친구추가 요청자의 ID 반환";
+        return ResponseEntity.ok(ApiResponseForm.success(getFriendshipRequesterResponse, message));
+    }
+
+    @PostMapping("/update-status/{uuid}") // 친구 추가 요청 수락
+    public ResponseEntity<ApiResponseForm<String>> updateAcceptStatus(HttpServletRequest request, @PathVariable String uuid, @RequestBody UpdateAcceptStatusDto updateAcceptStatusDto) {
+        Long userId = userAuthService.getUserIdFromToken(request);
+
+        friendShipService.updateAcceptStatus(userId, UUID.fromString(uuid), updateAcceptStatusDto.getAcceptStatus());
+
+        String status = updateAcceptStatusDto.getAcceptStatus().equals("ACCEPTED") ? "수락" : "거절";
+        String message = "친구추가 요청 " + status + " 성공";
+        return ResponseEntity.ok(ApiResponseForm.success(null, message));
+    }
+
+    @GetMapping("/list") // 친구 목록 조회
+    public ResponseEntity<ApiResponseForm<GetFriendListResponse>> getFriendList(HttpServletRequest request) {
+        Long userId = userAuthService.getUserIdFromToken(request);
+
+        List<FriendDto> friendsList = friendShipService.getFriendList(userId);
+        GetFriendListResponse getFriendsListResponse = GetFriendListResponse.builder()
+                .friendsList(friendsList)
+                .build();
+
+        String message = "친구 목록 조회 성공";
+        return ResponseEntity.ok(ApiResponseForm.success(getFriendsListResponse, message));
+    }
+
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/controller/FriendShipController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/FriendShipController.java
@@ -1,5 +1,6 @@
 package devkor.ontime_back.controller;
 
+import devkor.ontime_back.dto.CreateFriendshipLinkResponse;
 import devkor.ontime_back.dto.FriendDto;
 import devkor.ontime_back.dto.GetFriendshipRequesterResponse;
 import devkor.ontime_back.dto.UpdateAcceptStatusDto;
@@ -9,6 +10,11 @@ import devkor.ontime_back.response.ApiResponseForm;
 import devkor.ontime_back.service.FriendshipService;
 import devkor.ontime_back.service.UserAuthService;
 import devkor.ontime_back.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,16 +32,63 @@ public class FriendShipController {
     private final UserService userService;
     private final FriendshipService friendShipService;
 
+
+    @Operation(
+            summary = "친구 추가 링크 생성 및 반환",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "친구 추가 링크 생성 및 반환 요청 JSON 데이터는 없음. 헤더에 토큰만 있으면 됨",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{}"
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구추가 링크 생성 및 반환 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음. (반환되는 UUID는 서버에서 랜덤 제너레이팅 된 UUID임)", content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"친구추가 링크 생성 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음.\",\n  \"data\": {\n    \"friendShipId\": \"3fa85f64-5717-4562-b3fc-2c963f66afe5\"\n  }\n}"
+                    )
+            )),
+            @ApiResponse(responseCode = "4XX", description = "친구추가 링크 생성 및 반환 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
+    })
     @PostMapping("/link/create") // 친구 추가 링크 생성
-    public ResponseEntity<ApiResponseForm<String>> createFriendShipLink(HttpServletRequest request) {
+    public ResponseEntity<ApiResponseForm<CreateFriendshipLinkResponse>> createFriendShipLink(HttpServletRequest request) {
         Long userId = userAuthService.getUserIdFromToken(request);
 
-        String friendShipUUID =friendShipService.createFriendShipLink(userId);
+        CreateFriendshipLinkResponse createFriendshipLinkResponse = CreateFriendshipLinkResponse.builder()
+                .friendShipId(friendShipService.createFriendShipLink(userId))
+                .build();
 
-        String message = "친구추가 링크 생성 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음.";
-        return ResponseEntity.ok(ApiResponseForm.success(friendShipUUID, message));
+        String message = "친구추가 링크 생성 및 반환 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음.";
+        return ResponseEntity.ok(ApiResponseForm.success(createFriendshipLinkResponse, message));
     }
 
+    @Operation(
+            summary = "친구 추가 요청자 조회",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "친구 추가 요청자 조회 JSON 데이터는 없음. 헤더에 토큰과 쿼리파라미터(UUID)만 있으면 됨",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{}"
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구추가 요청자 조회 성공", content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"친구추가 요청자 조회 성공\",\n  \"data\": {\n    \"requesterId\": 2,\n    \"requesterName\": \"junbeommmm\",\n    \"requesterEmail\": \"userrrr@example.com\"\n  }\n}"
+                    )
+            )),
+            @ApiResponse(responseCode = "4XX", description = "친구추가 요청자 조회 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
+    })
     @GetMapping("/add-requester/{uuid}") // 친구 추가 요청자 조회
     public ResponseEntity<ApiResponseForm<GetFriendshipRequesterResponse>> getFriendShipRequester(HttpServletRequest request, @PathVariable String uuid) {
         Long userId = userAuthService.getUserIdFromToken(request);
@@ -47,10 +100,32 @@ public class FriendShipController {
                 .requesterEmail(requester.getEmail())
                 .build();
 
-        String message = "친구추가 요청자 조회 성공. 친구추가 요청자의 ID 반환";
+        String message = "친구추가 요청자 조회 성공";
         return ResponseEntity.ok(ApiResponseForm.success(getFriendshipRequesterResponse, message));
     }
 
+    @Operation(
+            summary = "친구추가 수락상태 업데이트",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "친구추가 수락상태 업데이트 요청 JSON 데이터. acceptStatus 값으로 \"ACCEPTED\" 또는 \"REJECTED\"만 가능함.",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{\n  \"acceptStatus\": \"ACCEPTED\"\n}"
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구추가 요청을 수락 또는 거절할 수 있음. 거절 시에는 \"친구추가 요청 거절 성공\" 메세지가 출력됨.", content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"친구추가 요청 수락 성공\",\n  \"data\": null\n}"
+                    )
+            )),
+            @ApiResponse(responseCode = "4XX", description = "친구추가 수락상태 업데이트 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
+    })
     @PostMapping("/update-status/{uuid}") // 친구 추가 요청 수락
     public ResponseEntity<ApiResponseForm<String>> updateAcceptStatus(HttpServletRequest request, @PathVariable String uuid, @RequestBody UpdateAcceptStatusDto updateAcceptStatusDto) {
         Long userId = userAuthService.getUserIdFromToken(request);
@@ -62,6 +137,28 @@ public class FriendShipController {
         return ResponseEntity.ok(ApiResponseForm.success(null, message));
     }
 
+    @Operation(
+            summary = "친구 목록 조회",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "친구 목록 조회 JSON 데이터는 없음. 헤더에 토큰만 있으면 됨",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{}"
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구 목록 조회 성공", content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"친구 목록 조회 성공\",\n  \"data\": [\n    {\n      \"friendId\": 2,\n      \"friendName\": \"junbeommmm\",\n      \"friendEmail\": \"userrrr@example.com\"\n    },\n    {\n      \"friendId\": 3,\n      \"friendName\": \"jinseoooo\",\n      \"friendEmail\": \"usererer@example.com\"\n    }\n  ]\n}"
+                    )
+            )),
+            @ApiResponse(responseCode = "4XX", description = "친구 목록 조회 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
+    })
     @GetMapping("/list") // 친구 목록 조회
     public ResponseEntity<ApiResponseForm<GetFriendListResponse>> getFriendList(HttpServletRequest request) {
         Long userId = userAuthService.getUserIdFromToken(request);

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/CreateFriendshipLinkResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/CreateFriendshipLinkResponse.java
@@ -1,0 +1,10 @@
+package devkor.ontime_back.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateFriendshipLinkResponse {
+    private String friendShipId;
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/FriendDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/FriendDto.java
@@ -1,0 +1,20 @@
+package devkor.ontime_back.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class FriendDto {
+    private Long friendId;
+    private String friendName;
+    private String friendEmail;
+
+    public FriendDto(Long friendId, String friendName, String friendEmail) {
+        this.friendId = friendId;
+        this.friendName = friendName;
+        this.friendEmail = friendEmail;
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/GetFriendshipRequesterResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/GetFriendshipRequesterResponse.java
@@ -1,0 +1,20 @@
+package devkor.ontime_back.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class GetFriendshipRequesterResponse {
+    private Long requesterId;
+    private String requesterName;
+    private String requesterEmail;
+
+    @Builder
+    public GetFriendshipRequesterResponse(Long requesterId, String requesterName, String requesterEmail) {
+        this.requesterId = requesterId;
+        this.requesterName = requesterName;
+        this.requesterEmail = requesterEmail;
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateAcceptStatusDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateAcceptStatusDto.java
@@ -1,0 +1,10 @@
+package devkor.ontime_back.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class UpdateAcceptStatusDto {
+    private String acceptStatus;
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/GetFriendListResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/GetFriendListResponse.java
@@ -1,0 +1,16 @@
+package devkor.ontime_back.entity;
+
+import devkor.ontime_back.dto.FriendDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class GetFriendListResponse {
+
+    private List<FriendDto> friendsList;
+
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/service/FriendshipService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/FriendshipService.java
@@ -103,8 +103,6 @@ public class FriendshipService {
 
         friendList.addAll(friendList2);
 
-        System.out.println("friendList: " + friendList);
-
         return friendList;
     }
 

--- a/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
@@ -1,11 +1,13 @@
 package devkor.ontime_back;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import devkor.ontime_back.controller.FriendShipController;
 import devkor.ontime_back.controller.ScheduleController;
 import devkor.ontime_back.controller.UserAuthController;
 import devkor.ontime_back.controller.UserController;
 import devkor.ontime_back.global.generallogin.handler.LoginSuccessHandler;
 import devkor.ontime_back.repository.UserRepository;
+import devkor.ontime_back.service.FriendshipService;
 import devkor.ontime_back.service.ScheduleService;
 import devkor.ontime_back.service.UserAuthService;
 import devkor.ontime_back.service.UserService;
@@ -19,7 +21,8 @@ import org.springframework.test.web.servlet.MockMvc;
         controllers = {
                 UserAuthController.class,
                 UserController.class,
-                ScheduleController.class
+                ScheduleController.class,
+                FriendShipController.class
         }
 )
 public abstract class ControllerTestSupport {
@@ -37,6 +40,12 @@ public abstract class ControllerTestSupport {
     protected UserService userService;
 
     @MockBean
+    protected ScheduleService scheduleService;
+
+    @MockBean
+    protected FriendshipService friendshipService;
+
+    @MockBean
     protected UserRepository userRepository;
 
     @MockBean
@@ -44,8 +53,5 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected LoginSuccessHandler loginSuccessHandler;
-
-    @MockBean
-    protected ScheduleService scheduleService;
 
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/FriendShipControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/FriendShipControllerTest.java
@@ -1,0 +1,163 @@
+package devkor.ontime_back.controller;
+
+import devkor.ontime_back.ControllerTestSupport;
+import devkor.ontime_back.TestSecurityConfig;
+import devkor.ontime_back.dto.FriendDto;
+import devkor.ontime_back.dto.UpdateSpareTimeDto;
+import devkor.ontime_back.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestSecurityConfig.class)
+class FriendShipControllerTest extends ControllerTestSupport {
+
+    @DisplayName("친구추가 링크 생성에 성공한다.")
+    @Test
+    void createFriendShipLink() throws Exception {
+        // given
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+
+        UUID uuid = UUID.randomUUID();
+        when(friendshipService.createFriendShipLink(any())).thenReturn(String.valueOf(uuid));
+
+
+        // when // then
+        mockMvc.perform(
+                        post("/friends/link/create")
+                                .content("")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("친구추가 링크 생성 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음."))
+                .andExpect(jsonPath("$.data").value(String.valueOf(uuid)));
+    }
+
+    @DisplayName("친구추가 요청자 조회에 성공한다")
+    @Test
+    void getFriendShipRequester() throws Exception {
+        // given
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+
+        User addedUser = User.builder()
+                .id(1L)
+                .name("junbeom")
+                .email("user@example.com")
+                .build();
+        when(friendshipService.getFriendShipRequester(any(Long.class), any(UUID.class))).thenReturn(addedUser);
+
+
+        // when // then
+        mockMvc.perform(
+                        get("/friends/add-requester/" + UUID.randomUUID())
+                                .content("")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("친구추가 요청자 조회 성공. 친구추가 요청자의 ID 반환"))
+                .andExpect(jsonPath("$.data.requesterId").value(1))
+                .andExpect(jsonPath("$.data.requesterName").value("junbeom"))
+                .andExpect(jsonPath("$.data.requesterEmail").value("user@example.com"));
+    }
+
+    @DisplayName("친구추가 요청 수락에 성공한다")
+    @Test
+    void updateAcceptStatusToAccepted() throws Exception {
+        // given
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        doNothing().when(friendshipService).updateAcceptStatus(any(Long.class), any(UUID.class), any(String.class));
+
+        // when // then
+        mockMvc.perform(
+                        post("/friends/accept/" + UUID.randomUUID())
+                                .content("{\"acceptStatus\": \"ACCEPTED\"}")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("친구추가 요청 수락 성공"));
+    }
+
+    @DisplayName("친구추가 요청 거절에 성공한다")
+    @Test
+    void updateAcceptStatusToREJECTED() throws Exception {
+        // given
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        doNothing().when(friendshipService).updateAcceptStatus(any(Long.class), any(UUID.class), any(String.class));
+
+        // when // then
+        mockMvc.perform(
+                        post("/friends/accept/" + UUID.randomUUID())
+                                .content("{\"acceptStatus\": \"REJECTED\"}")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("친구추가 요청 거절 성공"));
+    }
+
+    @DisplayName("친구 목록 조회에 성공한다")
+    @Test
+    void getFriendList() throws Exception {
+        // given
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+
+        List<FriendDto> mockFriendList = List.of(
+                FriendDto.builder()
+                        .friendId(2L)
+                        .friendName("friend1")
+                        .friendEmail("friend1@example.com")
+                        .build(),
+
+                FriendDto.builder()
+                        .friendId(3L)
+                        .friendName("friend2")
+                        .friendEmail("friend2@example.com")
+                        .build()
+        );
+        when(friendshipService.getFriendList(any(Long.class))).thenReturn(mockFriendList);
+
+        // when // then
+        mockMvc.perform(
+                        get("/friends/list")
+                                .content("")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("친구 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.friendsList").isArray())
+                .andExpect(jsonPath("$.data.friendsList").isNotEmpty())
+                .andExpect(jsonPath("$.data.friendsList[0].friendId").value(2))
+                .andExpect(jsonPath("$.data.friendsList[0].friendName").value("friend1"))
+                .andExpect(jsonPath("$.data.friendsList[0].friendEmail").value("friend1@example.com"))
+                .andExpect(jsonPath("$.data.friendsList[1].friendId").value(3))
+                .andExpect(jsonPath("$.data.friendsList[1].friendName").value("friend2"))
+                .andExpect(jsonPath("$.data.friendsList[1].friendEmail").value("friend2@example.com"));
+    }
+}

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/FriendShipControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/FriendShipControllerTest.java
@@ -45,8 +45,8 @@ class FriendShipControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.message").value("친구추가 링크 생성 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음."))
-                .andExpect(jsonPath("$.data").value(String.valueOf(uuid)));
+                .andExpect(jsonPath("$.message").value("친구추가 링크 생성 및 반환 성공. 반환되는 UUID로 친구추가 요청 데이터를 조회하고, 친구추가 요청을 수락하거나 거절할 수 있음."))
+                .andExpect(jsonPath("$.data.friendShipId").value(uuid.toString()));
     }
 
     @DisplayName("친구추가 요청자 조회에 성공한다")
@@ -73,7 +73,7 @@ class FriendShipControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.message").value("친구추가 요청자 조회 성공. 친구추가 요청자의 ID 반환"))
+                .andExpect(jsonPath("$.message").value("친구추가 요청자 조회 성공"))
                 .andExpect(jsonPath("$.data.requesterId").value(1))
                 .andExpect(jsonPath("$.data.requesterName").value("junbeom"))
                 .andExpect(jsonPath("$.data.requesterEmail").value("user@example.com"));
@@ -88,7 +88,7 @@ class FriendShipControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(
-                        post("/friends/accept/" + UUID.randomUUID())
+                        post("/friends/update-status/" + UUID.randomUUID())
                                 .content("{\"acceptStatus\": \"ACCEPTED\"}")
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -108,7 +108,7 @@ class FriendShipControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(
-                        post("/friends/accept/" + UUID.randomUUID())
+                        post("/friends/update-status/" + UUID.randomUUID())
                                 .content("{\"acceptStatus\": \"REJECTED\"}")
                                 .contentType(MediaType.APPLICATION_JSON)
                 )

--- a/ontime-back/src/test/java/devkor/ontime_back/service/FriendshipServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/FriendshipServiceTest.java
@@ -1,5 +1,6 @@
 package devkor.ontime_back.service;
 
+import devkor.ontime_back.dto.FriendDto;
 import devkor.ontime_back.entity.FriendShip;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.repository.FriendshipRepository;
@@ -16,7 +17,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class FriendshipServiceTest {
@@ -57,8 +57,7 @@ class FriendshipServiceTest {
 
         // then
         assertThat(returnedLink).isNotNull();
-        assertThat(returnedLink).contains("http://ontime.com/friendship/");
-        assertThat(friendshipRepository.findByFriendShipId(UUID.fromString(returnedLink.substring(29)))).isNotNull();
+        assertThat(friendshipRepository.findByFriendShipId(UUID.fromString(returnedLink))).isNotNull();
     }
 
     @DisplayName("친구추가 링크 생성시 잘못된 유저가 전달되는 경우 에외가 발생한다")
@@ -85,7 +84,7 @@ class FriendshipServiceTest {
     @DisplayName("친구추가 요청자 정보 조회에 성공한다." +
             "(Friendship 데이터의 receiverId를 세팅하고 해당 데이터의 수신자 User 정보를 반환에 성공한다.)")
     @Test
-    void getFriendRequester(){
+    void getFriendShipRequester(){
         // given
         User addedRequester = User.builder()
                 .email("user@example.com")
@@ -114,7 +113,7 @@ class FriendshipServiceTest {
         friendshipRepository.save(friendShip);
 
         // when
-        User returnedRequester = friendshipService.getFriendRequester(addedReceiver.getId(), friendShip.getFriendShipId());
+        User returnedRequester = friendshipService.getFriendShipRequester(addedReceiver.getId(), friendShip.getFriendShipId());
 
         // then
         // 1. 수신자 ID 세팅 확인 2. 요청자 정보 반환 확인
@@ -127,7 +126,7 @@ class FriendshipServiceTest {
 
     @DisplayName("친구추가 요청자 정보 조회 시 잘못된 유저id가 전달될 때 예외가 발생한다.")
     @Test
-    void getFriendRequesterWithWrongUserId(){
+    void getFriendShipRequesterWithWrongUserId(){
         // given
         User addedRequester = User.builder()
                 .email("user@example.com")
@@ -156,14 +155,14 @@ class FriendshipServiceTest {
         friendshipRepository.save(friendShip);
 
         // when // then
-        assertThatThrownBy(() -> friendshipService.getFriendRequester(addedReceiver.getId() + 123456789, friendShip.getFriendShipId()))
+        assertThatThrownBy(() -> friendshipService.getFriendShipRequester(addedReceiver.getId() + 123456789, friendShip.getFriendShipId()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("존재하지 않는 유저 id입니다.");
     }
 
     @DisplayName("친구추가 요청자 정보 조회 시 잘못된 친구관계id(UUID)가 전달될 때 예외가 발생한다.")
     @Test
-    void getFriendRequesterWithWrongFriendShipId(){
+    void getFriendRequesterWithWrongFriendShipShipId(){
         // given
         User addedRequester = User.builder()
                 .email("user@example.com")
@@ -192,14 +191,14 @@ class FriendshipServiceTest {
         friendshipRepository.save(friendShip);
 
         // when // then
-        assertThatThrownBy(() -> friendshipService.getFriendRequester(addedReceiver.getId(), UUID.randomUUID()))
+        assertThatThrownBy(() -> friendshipService.getFriendShipRequester(addedReceiver.getId(), UUID.randomUUID()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("존재하지 않는 친구 요청입니다.");
     }
 
     @DisplayName("친구추가 요청자 정보 조회 시 잘못된 친구추가 요청자id가 전달될 때 예외가 발생한다.")
     @Test
-    void getFriendRequesterWithWrongRequeseterId(){
+    void getFriendShipRequesterWithWrongRequeseterId(){
         // given
         User addedRequester = User.builder()
                 .email("user@example.com")
@@ -231,7 +230,7 @@ class FriendshipServiceTest {
         userRepository.delete(addedRequester);
 
         // when // then
-        assertThatThrownBy(() -> friendshipService.getFriendRequester(addedReceiver.getId(), friendShip.getFriendShipId()))
+        assertThatThrownBy(() -> friendshipService.getFriendShipRequester(addedReceiver.getId(), friendShip.getFriendShipId()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("존재하지 않는 친구추가 요청자 id입니다. 해당 유저가 탈퇴했을 수 있습니다.");
     }
@@ -425,7 +424,7 @@ class FriendshipServiceTest {
     }
 
 
-    @DisplayName("친구 목록을 조회에 성공한다")
+    @DisplayName("친구 목록 조회에 성공한다")
     @Test
     void getAcceptedFriendList(){
         // given
@@ -457,17 +456,17 @@ class FriendshipServiceTest {
         friendshipRepository.save(friendShip);
 
         // when
-        List<User> friendListWithRequesterId = friendshipService.getFriendList(addedRequester.getId());
-        List<User> friendListWithReceiverId = friendshipService.getFriendList(addedReceiver.getId());
+        List<FriendDto> friendListWithRequesterId = friendshipService.getFriendList(addedRequester.getId());
+        List<FriendDto> friendListWithReceiverId = friendshipService.getFriendList(addedReceiver.getId());
 
         // then
         assertThat(friendListWithRequesterId).isNotEmpty();
         assertThat(friendListWithRequesterId).hasSize(1);
-        assertThat(friendListWithRequesterId.get(0).getId()).isEqualTo(addedReceiver.getId());
+        assertThat(friendListWithRequesterId.get(0).getFriendId()).isEqualTo(addedReceiver.getId());
 
         assertThat(friendListWithReceiverId).isNotEmpty();
         assertThat(friendListWithReceiverId).hasSize(1);
-        assertThat(friendListWithReceiverId.get(0).getId()).isEqualTo(addedRequester.getId());
+        assertThat(friendListWithReceiverId.get(0).getFriendId()).isEqualTo(addedRequester.getId());
     }
 
     @DisplayName("친구 목록 조회 시 아직 친구요청을 받지 않았을 때 해당 관계의 친구는 반환되지 않는다.")
@@ -502,8 +501,8 @@ class FriendshipServiceTest {
         friendshipRepository.save(friendShip);
 
         // when
-        List<User> friendListWithRequesterId = friendshipService.getFriendList(addedRequester.getId());
-        List<User> friendListWithReceiverId = friendshipService.getFriendList(addedReceiver.getId());
+        List<FriendDto> friendListWithRequesterId = friendshipService.getFriendList(addedRequester.getId());
+        List<FriendDto> friendListWithReceiverId = friendshipService.getFriendList(addedReceiver.getId());
 
         // then
         assertThat(friendListWithRequesterId).isEmpty();
@@ -525,7 +524,7 @@ class FriendshipServiceTest {
         userRepository.save(addedUser);
 
         // when
-        List<User> friendListWithRequesterId = friendshipService.getFriendList(addedUser.getId());
+        List<FriendDto> friendListWithRequesterId = friendshipService.getFriendList(addedUser.getId());
 
         // then
         assertThat(friendListWithRequesterId).isEmpty();


### PR DESCRIPTION
## 작성한 코드
- **친구 추가 링크 생성 및 반환 API** 컨트롤러 계층 코드 및 테스트 코드 작성 완료
- **친구 추가 페이지 반환 API** 컨트롤러 계층 코드 및 테스트 코드 작성 완료
- **친구추가 수락상태 업데이트 API** 컨트롤러 계층 코드 및 테스트 코드 작성 완료
- **친구목록 조회 API** 컨트롤러 계층 코드 및 테스트 코드 작성 완료
- 위 모든 API에 대해 **Swagger API 명세** 완료

## 확인해야할 사항
- **TDD(Test Driven Development)** 개발 방식으로 코드 작성하여 테스트 코드를 먼저 작성하고 프로덕션 코드를 작성해(RED-GREEN-REFACTOR) **엣지 케이스**를 충분히 고려하여 작성하였음.
- 친구 추가 링크를 통해 친구추가 하는 방식에는 아래의 두 가지 방법이 있으나 **일단은 1번 방식으로 구현**하였음. 친구 추가 링크 생성 및 반환 API를 통해 반환받은 UUID로 FE에서 링크를 구성하고 복사를 하면, 해당 링크는 친구 추가를 하려는 대상 1명에게만 유효함. 누군가 해당 링크를 클릭하면 그 링크는 더 이상 사용할 수 없게 됨.

> 1. 친구추가 하고자하는 대상 1명에게만 사용 가능
> 2. 친구추가 하고자하는 대상 여러명에게 사용 가능

- 차후 기획단에서 2번 방식을 명확히 요구하면 코드 수정이 필요해보임
- API 명세서의 **2. 친구 추가 페이지 반환 API**는 GET메소드를 사용하는데, 비즈니스레이어에서 데이터를 변경함. 이 부분 차후 리팩토링이 필요해보임.
- 링크 복사 외에 **카카오톡으로 바로 초대** 기능도 구현해야 함


## 친구 추가 기능 API 명세서
### 1. 친구 추가 링크 생성 및 반환 API (**POST** /friends/link/create)###
- 친구관계를 의미하는 **FriendShip테이블의 데이터를 생성**하고 **해당 데이터의 PK를 반환**하는 API
- 본 API를 호출하면 FriendShip테이블의 데이터를 생성하고 PK인 **UUID를 반환하는데 FE에서 이 UUID를 이용해 _2. 친구 추가 페이지 반환 API_와 _3. 친구추가 수락상태 업데이트 API_를 호출할 수 있음.**
- 사용자가 '친구추가 링크 생성하기' 버튼을 누르면 호출하면 됨.

> **POST** /friends/link/create
> **요청헤더**: 엑세스토큰 //FriendShip 테이블의 친구추가 요청자 id를 세팅하기 위함.
> **요청바디**: -
> 
> **반환바디**: friendShipId(데이터타입: UUID)


### 2. 친구 추가 요청자 조회 API (**GET** /friends/add-requester/{uuid}) ###
- 조회하려는 FriendShip 데이터의 **수신자 id를 세팅**하고 **요청자 정보를 반환**하는 API
- 본 API를 호출하면 쿼리파라미터의 UUID를 바탕으로 **FriendShip 데이터를 조회한 뒤, 해당 데이터의 수신자 id를 설정하고 요청자의 id, 이름, 이메일을 반환함.**
- **사용자가 딥링크를 클릭해 "~~님이 친구추가를 요청하셨습니다"라는 페이지를 반환해야할 때 호출하면 됨.**

> **GET** /friends/add-requester/{uuid}
> **요청헤더**: 엑세스토큰 //FriendShip 테이블의 친구추가 수신자 id를 세팅하기 위함.
> **요청바디**: -
> 
> **반환바디**: requesterId(데이터타입: Long)
                         requesterName(데이터타입: String)
                         requesterEmail(데이터타입: String)


### 3. 친구추가 수락상태 업데이트 API (**POST** /friends/update-status/{uuid}) ###
- FriendShip 데이터의 **수락상태를 업데이트**하는 API
- 본 API를 호출하면 요청바디의 acceptStatus를 바탕으로 **FriendShip 데이터의 수락상태를 변경**함.("PENDING" -> "ACCEPTED" 또는 "REJECTED")
- **사용자가 "~~님이 친구추가를 요청하셨습니다"페이지에서 수락하기 또는 거절하기 버튼을 눌렀을 때 호출하면 됨.**

> **POST** /friends/update-status/{uuid}
> **요청헤더**: 엑세스토큰
> **요청바디**:  acceptStatus // 값으로 **"ACCEPTED" 또는 "REJECTED"만 가능**함
> 
> **반환바디**: -

### 4. 친구목록 조회 API (**GET** /friends/list) ###
- 호출한 사용자의 **친구 목록을 반환**하는 API
- 본 API를 호출하면 엑세스토큰의 사용자 정보를 바탕으로 FriendShip테이블에서 수신자/요청자ID를 매칭하고 수락여부가 **'ACCEPTED'**인 데이터를 찾아서 상대방 ID, 이름, 이메일을 조회 및 반환함.
- **사용자의 친구목록을 불러와야할 때 호출하면 됨.**

> **GET** /friends/list
> **요청헤더**: 엑세스토큰
> **요청바디**: -
> 
> **반환바디**: { 
friendId(데이터타입: Long)
friendName(데이터타입: String)
friendEmail(데이터타입: String)
}
의 **리스트**

## 코드를 작성하며 생긴 이슈 & 학습한 내용
#### API 설계 ####
- 친구추가 API들을 구현할 때 API명세서를 먼저 작성하고 코드를 작성하였는데 API 명세서가 자연어로 코드의 흐름을 문서화했을 때의 기능을 해 코드를 작성하는 중간중간 API 명세서를 참고하면서 큰 흐름을 파악할 수 있어 편했음. 
- 미리 큰 틀을 자연어로 작성했음에도 불구하고 코드를 다 작성하고 테스트를 하는 과정에서 링크 친구추가 방법에는 아래 2가지 케이스가 있음을 깨달았음.
> 1. 친구추가 하고자하는 대상 1명에게만 사용 가능
> 2. 친구추가 하고자하는 대상 여러명에게 사용 가능
- API를 설계(명세서 작성)할 때 조금 더 치밀하게 생각할 필요가 있어보임.

#### TDD ####
- 지금까지 구현한 API들에 대해 테스트 코드를 작성하기 위해 테스트 코드를 공부하면서 테스트 코드의 철학에 대해 이해할 수 있었고 **TDD개발방식**에 관심을 가지게 되었음. TDD개발방식은 기능 개발보다 테스트를 먼저하는 개발 방식으로, **엣지 케이스**를 놓치지 않고 테스트 코드를 작성할 수 있게 해주며 프로덕션 코드를 유연하며 유지보수가 쉬운 즉, **테스트 가능한 코드**로 구현할 수 있께 해준다는 장점이 있음. 또한 구현에 대한 **빠른 피드백**이 가능해져 **과감한 리팩토링**이 가능함. 이를 친구추가 API 구현에 적용해 TDD의 장점을 느낄 수 있었음.
- **@DisplayName** 애너테이션을 통해 테스트 코드를 프로덕션 기능을 설명하는 **문서로서의 역할**을 할 수 있게끔 하였음.

## 전체 테스트 결과
[Test Results — ontime-back [test].pdf](https://github.com/user-attachments/files/18560965/Test.Results.ontime-back.test.pdf)
