### PR TITLE
[Hotfix] 온보딩 관련 API 대거 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationUserController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationUserController.java
@@ -26,30 +26,30 @@ public class PreparationUserController {
     private final PreparationUserService preparationUserService;
 
 
-    @Operation(
-            summary = "사용자 준비과정 첫 세팅",
-            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "사용자 준비과정 관련 JSON 데이터",
-                    required = true,
-                    content = @Content(
-                            schema = @Schema(
-                                    type = "object",
-                                    example = "[\n {\n \"preparationId\": \"123e4567-e89b-12d3-a456-426614174011\",\n \"preparationName\": \"Step 1: Wake up\",\n \"preparationTime\": 5,\n \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174012\"\n },\n {\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174012\",\n\"preparationName\": \"Step 2: Brush teeth\",\n \"preparationTime\": 15,\n \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174013\"\n },\n {\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174013\",\n\"preparationName\": \"Step 3: Wearing Clothes\",\n\"preparationTime\": 15,\n\"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174014\"\n },\n{\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174014\",\n\"preparationName\": \"Step 4: Breakfast\",\n\"preparationTime\": 30,\n\"nextPreparationId\": null\n }\n ]"
-                            )
-                    )
-            )
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자 준비과정 세팅 완료", content = @Content(mediaType = "application/json", schema = @Schema(example = "{\n\"status\": \"success\",\n \"code\": \"200\",\n \"message\": \"OK\",\n \"data\": null\n }"))),
-            @ApiResponse(responseCode = "4XX", description = "잘못된 요청", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
-    })
-    @PostMapping("/set/first")
-    public ResponseEntity<ApiResponseForm<Void>> setFirstPreparationUser(HttpServletRequest request, @RequestBody List<PreparationDto> preparationDtoList) {
-        Long userId = preparationUserService.getUserIdFromToken(request);
-
-        preparationUserService.setFirstPreparationUser(userId, preparationDtoList);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseForm.success(null));
-    }
+//    @Operation(
+//            summary = "사용자 준비과정 첫 세팅",
+//            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+//                    description = "사용자 준비과정 관련 JSON 데이터",
+//                    required = true,
+//                    content = @Content(
+//                            schema = @Schema(
+//                                    type = "object",
+//                                    example = "[\n {\n \"preparationId\": \"123e4567-e89b-12d3-a456-426614174011\",\n \"preparationName\": \"Step 1: Wake up\",\n \"preparationTime\": 5,\n \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174012\"\n },\n {\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174012\",\n\"preparationName\": \"Step 2: Brush teeth\",\n \"preparationTime\": 15,\n \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174013\"\n },\n {\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174013\",\n\"preparationName\": \"Step 3: Wearing Clothes\",\n\"preparationTime\": 15,\n\"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174014\"\n },\n{\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174014\",\n\"preparationName\": \"Step 4: Breakfast\",\n\"preparationTime\": 30,\n\"nextPreparationId\": null\n }\n ]"
+//                            )
+//                    )
+//            )
+//    )
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "사용자 준비과정 세팅 완료", content = @Content(mediaType = "application/json", schema = @Schema(example = "{\n\"status\": \"success\",\n \"code\": \"200\",\n \"message\": \"OK\",\n \"data\": null\n }"))),
+//            @ApiResponse(responseCode = "4XX", description = "잘못된 요청", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
+//    })
+//    @PostMapping("/set/first")
+//    public ResponseEntity<ApiResponseForm<Void>> setFirstPreparationUser(HttpServletRequest request, @RequestBody List<PreparationDto> preparationDtoList) {
+//        Long userId = preparationUserService.getUserIdFromToken(request);
+//
+//        preparationUserService.setFirstPreparationUser(userId, preparationDtoList);
+//        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseForm.success(null));
+//    }
 
     @Operation(
             summary = "사용자 준비과정 수정",

--- a/ontime-back/src/main/java/devkor/ontime_back/controller/UserAuthController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/UserAuthController.java
@@ -29,7 +29,7 @@ public class UserAuthController {
     private final UserRepository userRepository;
 
     @Operation(
-            summary = "일반 회원가입",
+            summary = "일반 회원가입 (회원가입 시 자동으로 로그인도 되어 헤더에 JWT토큰을 반환함)",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "회원가입 요청 JSON 데이터",
                     required = true,
@@ -42,7 +42,7 @@ public class UserAuthController {
             @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(
                     mediaType = "application/json",
                     schema = @Schema(
-                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"회원가입이 성공적으로 완료되었습니다. 추가 정보를 기입해주세요( {userId}/additional-info )\",\n  \"data\": {\n    \"userId\": 1\n  }}"
+                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"회원가입이 성공적으로 완료되었습니다. 온보딩을 진행해주세요( /user/onboarding )\",\n  \"data\": {\n    \"userId\": 1\n  }}"
                     )
             )),
             @ApiResponse(responseCode = "4XX", description = "회원가입 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(이메일이 이미 존재할 경우, 이름이 이미 존재할 경우 다르게 출력)")))
@@ -51,14 +51,14 @@ public class UserAuthController {
     public ResponseEntity<ApiResponseForm<UserSignUpResponse>> signUp(HttpServletRequest request, HttpServletResponse response, @RequestBody UserSignUpDto userSignUpDto) throws Exception {
         User user = userAuthService.signUp(request, response, userSignUpDto);
 
-        String message = "회원가입이 성공적으로 완료되었습니다. 추가 정보를 기입해주세요( {userId}/additional-info )";
+        String message = "회원가입이 성공적으로 완료되었습니다. 온보딩을 진행해주세요( /user/onboarding )";
         return ResponseEntity.ok(ApiResponseForm.success(new UserSignUpResponse(user.getId()), message));
     }
 
 
     @Operation(summary = "일반 로그인 (로그인 요청을 통해 JWT 토큰을 발급받음)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "일반 로그인 성공(반환 문자열 없음. 헤더에 토큰 반환)", content = @Content(mediaType = "application/json", schema = @Schema(example = " "))),
+            @ApiResponse(responseCode = "200", description = "일반 로그인 성공(반환 문자열 없음. 헤더에 토큰 반환)", content = @Content(mediaType = "application/json", schema = @Schema(example = "{\n  \"message\": \"유저의 ROLE이 GUEST이므로 온보딩API를 호출해 온보딩을 진행해야합니다.\", \"role\": \"GUEST\"}"))),
             @ApiResponse(responseCode = "4XX", description = "일반 로그인 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
     })
     @PostMapping("/login")
@@ -135,38 +135,6 @@ public class UserAuthController {
         userAuthService.deleteUser(userId);
 
         String message = "계정이 성공적으로 삭제되었습니다!";
-        return ResponseEntity.ok(ApiResponseForm.success(null, message));
-    }
-
-
-    @Operation(
-            summary = "추가 정보 기입 (일반 회원가입 직후 추가 정보 기입)",
-            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "추가 정보 기입 요청 JSON 데이터",
-                    required = true,
-                    content = @Content(
-                            schema = @Schema(
-                                    type = "object",
-                                    example = "{\"spareTime\": 10, \"note\": \"이번엔 약속 꼭 지켜보자!\"}"
-                            )
-                    )
-            )
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "추가 정보 기입 성공", content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(
-                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"추가 정보가 성공적으로 기입되었습니다!\",\n  \"data\": null\n}"
-                    )
-            )),
-            @ApiResponse(responseCode = "4XX", description = "추가 정보 기입 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(토큰 오류 제외 비즈니스 로직 오류는 없음)")))
-    })
-    @PutMapping("/{userId}/additional-info")
-    public ResponseEntity<ApiResponseForm<?>> addInfo(
-            @PathVariable Long userId, @RequestBody UserAdditionalInfoDto userAdditionalInfoDto) throws Exception {
-        userAuthService.addInfo(userId, userAdditionalInfoDto);
-
-        String message = "추가 정보가 성공적으로 기입되었습니다!";
         return ResponseEntity.ok(ApiResponseForm.success(null, message));
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/controller/UserAuthController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/UserAuthController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -47,8 +48,8 @@ public class UserAuthController {
             @ApiResponse(responseCode = "4XX", description = "회원가입 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(이메일이 이미 존재할 경우, 이름이 이미 존재할 경우 다르게 출력)")))
     })
     @PostMapping("/sign-up")
-    public ResponseEntity<ApiResponseForm<UserSignUpResponse>> signUp(@RequestBody UserSignUpDto userSignUpDto) throws Exception {
-        User user = userAuthService.signUp(userSignUpDto);
+    public ResponseEntity<ApiResponseForm<UserSignUpResponse>> signUp(HttpServletRequest request, HttpServletResponse response, @RequestBody UserSignUpDto userSignUpDto) throws Exception {
+        User user = userAuthService.signUp(request, response, userSignUpDto);
 
         String message = "회원가입이 성공적으로 완료되었습니다. 추가 정보를 기입해주세요( {userId}/additional-info )";
         return ResponseEntity.ok(ApiResponseForm.success(new UserSignUpResponse(user.getId()), message));

--- a/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/UserController.java
@@ -125,5 +125,38 @@ public class UserController {
         return ResponseEntity.ok(ApiResponseForm.success(null, message));
     }
 
+
+    @Operation(
+            summary = "온보딩 (여유시간, 잊으면 안될 것들, 준비과정 첫 세팅)",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "온보딩 요청 JSON 데이터",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{\n  \"spareTime\": 30,\n  \"note\": \"내 인생에 지각은 없다!!!\",\n  \"preparationList\": [\n    {\n      \"preparationId\": \"123e4567-e89b-12d3-a456-426614174011\",\n      \"preparationName\": \"기상하기\",\n      \"preparationTime\": 10,\n      \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174012\"\n    },\n    {\n      \"preparationId\": \"123e4567-e89b-12d3-a456-426614174012\",\n      \"preparationName\": \"세수하기\",\n      \"preparationTime\": 10,\n      \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174013\"\n    },\n    {\n      \"preparationId\": \"123e4567-e89b-12d3-a456-426614174013\",\n      \"preparationName\": \"화장하기\",\n      \"preparationTime\": 10,\n      \"nextPreparationId\": null\n    }\n  ]\n}"
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "온보딩 성공", content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            example = "{\n  \"status\": \"success\",\n  \"code\": \"200\",\n  \"message\": \"온보딩이 성공적으로 완료되었습니다!\",\n  \"data\": null\n}"
+                    )
+            )),
+            @ApiResponse(responseCode = "4XX", description = "온보딩 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(토큰 오류 제외 비즈니스 로직 오류는 없음)")))
+    })
+    @PutMapping("/onboarding")
+    public ResponseEntity<ApiResponseForm<?>> addInfo(HttpServletRequest request, @RequestBody UserOnboardingDto userOnboardingDto) throws Exception {
+        Long userId = userAuthService.getUserIdFromToken(request);
+
+        userService.onboarding(userId, userOnboardingDto);
+
+        String message = "온보딩이 성공적으로 완료되었습니다!";
+        return ResponseEntity.ok(ApiResponseForm.success(null, message));
+    }
+
 }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserOnboardingDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserOnboardingDto.java
@@ -1,0 +1,12 @@
+package devkor.ontime_back.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UserOnboardingDto {
+    private Integer spareTime;
+    private String note;
+    private List<PreparationDto> preparationList;
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
@@ -4,6 +4,7 @@ import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.persister.entity.EntityNameUse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,6 +12,8 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -43,6 +46,25 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                     log.info("로그인에 성공하였습니다. 이메일 : {}", email);
                     log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
                     log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
+
+
+                    try {
+                        // 응답 Content-Type 설정
+                        response.setContentType("application/json");
+                        response.setCharacterEncoding("UTF-8");
+
+                        // JSON 응답 생성
+                        String responseBody = String.format(
+                                "{\"email\": \"%s\", \"role\": \"%s\"}",
+                                email, user.getRole().name()
+                        );
+
+                        // 응답 바디에 작성
+                        response.getWriter().write(responseBody);
+                        response.getWriter().flush();
+                    } catch (IOException e) {
+                        log.error("응답 바디 작성 중 오류 발생", e);
+                    }
                 });
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
@@ -53,10 +53,11 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                         response.setContentType("application/json");
                         response.setCharacterEncoding("UTF-8");
 
+                        String msg = user.getRole().name().equals("GUEST") ? "유저의 ROLE이 GUEST이므로 온보딩API를 호출해 온보딩을 진행해야합니다." : "로그인에 성공하였습니다.";
                         // JSON 응답 생성
                         String responseBody = String.format(
-                                "{\"email\": \"%s\", \"role\": \"%s\"}",
-                                email, user.getRole().name()
+                                "{\"message\": \"%s\", \"role\": \"%s\"}",
+                                msg, user.getRole().name()
                         );
 
                         // 응답 바디에 작성

--- a/ontime-back/src/main/java/devkor/ontime_back/service/UserService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/UserService.java
@@ -1,6 +1,8 @@
 package devkor.ontime_back.service;
 
 import devkor.ontime_back.dto.UpdateSpareTimeDto;
+import devkor.ontime_back.dto.UserAdditionalInfoDto;
+import devkor.ontime_back.dto.UserOnboardingDto;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserAuthService userAuthService;
+    private final PreparationUserService preparationUserService;
 
     // 성실도 점수 반환
     public Float getPunctualityScore(Long userId) {
@@ -72,5 +76,17 @@ public class UserService {
         userRepository.save(user);
 
         return user;
+    }
+
+    @Transactional
+    public void onboarding(Long userId, UserOnboardingDto userOnboardingDto) throws Exception {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 id입니다."));
+
+        user.updateAdditionalInfo(userOnboardingDto.getSpareTime(), userOnboardingDto.getNote());
+        userRepository.save(user);
+        preparationUserService.setFirstPreparationUser(userId, userOnboardingDto.getPreparationList());
+        user.authorizeUser();
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
## 확인해야할 사항
- 회원가입 API에서 자동로그인 처리 및 role을 GUEST로 설정하도록 코드를 수정함.
   회원가입 API를 호출하면, 회원가입이 되고 role을 GUEST로 설정한 뒤, JWT토큰을 헤더에 담아 반환함. 
   사용자의 role이 GUEST인 것의 의미는 해당 사용자가 온보딩이 진행되지 않은 사용자라는 뜻임.
- 로그인할 때마다 role을 반환하도록 로그인API(정확히는 스프링시큐리티의 로그인필터)를 수정함.
로그인시 반환role값이 GUEST이면 FE에서 온보딩 API를 호출해 온보딩을 진행해야 함.
- 추가정보기입API와 첫준비과정세팅API를 온보딩API로 합쳤음.
온보딩API를 호출하면 추가정보가 기입되고, 디폴트 준비과정이 세팅되며 role이 USER로 업데이트됨.(온보딩이 완료됐다는 의미)
온보딩API에서는 토큰으로 사용자 인증이 필요함.


## 회원가입 ~ 로그인 ~ 온보딩 플로우 정리
- **해피케이스**: 회원가입후 발급된 토큰으로 온보딩API를 호출해 온보딩을 완료하면 role이 USER(온보딩 완료)로 변경됨.
- **엣지케이스**: 회원가입만 하고 앱을 종료한 사용자는 앱을 다시 실행시키면 로그인을 해야함. 이때 로그인을 하면 role값으로 GUEST가 반환될 것임. FE에서는 로그인의 반환role값이 GUEST임을 확인하면 온보딩API를 호출해 해당 사용자의 온보딩을 진행시켜야함.