### PR TITLE
[mod] 지각히스토리 조회 API 성능 추가개선 / 연관관계에 지연로딩 세팅 및 필요시 페치조인 적용 / 테스트 코드 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/dto/PreparationDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/PreparationDto.java
@@ -1,6 +1,7 @@
 package devkor.ontime_back.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.sql.Time;
@@ -8,6 +9,7 @@ import java.util.UUID;
 
 @AllArgsConstructor
 @Getter
+@Builder
 public class PreparationDto {
     private UUID preparationId;
 

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserOnboardingDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserOnboardingDto.java
@@ -1,12 +1,15 @@
 package devkor.ontime_back.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@Builder
 public class UserOnboardingDto {
     private Integer spareTime;
     private String note;
     private List<PreparationDto> preparationList;
+
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/Feedback.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/Feedback.java
@@ -26,7 +26,7 @@ public class Feedback {
 
     private LocalDateTime createAt; // 약속시각
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/Schedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/Schedule.java
@@ -14,6 +14,12 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor // 기본 생성자 생성
 @AllArgsConstructor // 모든 필드를 포함하는 생성자 생성
+@Table(
+        indexes = {
+                @Index(name = "idx_schedule_user_id", columnList = "user_id"),
+                @Index(name = "idx_schedule_lateness_time", columnList = "latenessTime")
+        }
+)
 public class Schedule {
 
     @Id

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
@@ -55,13 +55,13 @@ public class User {
     @Setter
     private String firebaseToken;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "user", cascade = CascadeType.ALL)
     private UserSetting userSetting;
 
-    @OneToMany(mappedBy = "requesterId", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "requesterId", cascade = CascadeType.ALL)
     private List<FriendShip> requestedFriendship = new ArrayList<>();
 
-    @OneToMany(mappedBy = "receiverId", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "receiverId", cascade = CascadeType.ALL)
     private List<FriendShip> receivedFriendship = new ArrayList<>();
 
     public void updateAdditionalInfo(Integer spareTime, String note) {

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/UserSetting.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/UserSetting.java
@@ -18,7 +18,7 @@ public class UserSetting {
     @Id
     private UUID userSettingId; // 기본 키
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 사용자 ID (외래 키)
 

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/FriendshipRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/FriendshipRepository.java
@@ -2,6 +2,8 @@ package devkor.ontime_back.repository;
 
 import devkor.ontime_back.entity.FriendShip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,7 +15,11 @@ public interface FriendshipRepository extends JpaRepository<FriendShip, Long> {
 
     Optional<FriendShip> findByFriendShipId(UUID friendShipId);
 
-    List<FriendShip> findByRequesterIdAndAcceptStatus(Long userId, String accepted);
+    // Friendship에 어차피 User방향의 연관관계가 없으므로 조인 자체가 필요없어 페치조인 적용할 필요도 없음
+    @Query("SELECT f FROM FriendShip f WHERE f.requesterId = :userId AND f.acceptStatus = :accepted")
+    List<FriendShip> findByRequesterIdAndAcceptStatus(@Param("userId") Long userId, @Param("accepted") String accepted);
 
+    // Friendship에 어차피 User방향의 연관관계가 없으므로 조인 자체가 필요없어 페치조인 적용할 필요도 없음
+    @Query("SELECT f FROM FriendShip f WHERE f.receiverId = :userId AND f.acceptStatus = :accepted")
     List<FriendShip> findByReceiverIdAndAcceptStatus(Long userId, String accepted);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/ScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/ScheduleRepository.java
@@ -30,8 +30,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, UUID> {
     @Query("SELECT s FROM Schedule s WHERE FUNCTION('HOUR', s.scheduleTime) = :hour AND FUNCTION('MINUTE', s.scheduleTime) = :minute")
     List<Schedule> findSchedulesStartingAt(int hour, int minute);
 
-    // 지각 히스토리 조회(페치조인)
-    @Query("SELECT s FROM Schedule s JOIN FETCH s.user WHERE s.user.id = :userId AND s.latenessTime > 0")
+    // 지각 히스토리 조회(페치조인을 했었는데 본 메서드를 사용하는 서비스메서드에서 user를 참조하지 않아서 필요없음)
+    @Query("SELECT s FROM Schedule s WHERE s.user.id = :userId AND s.latenessTime > 0")
     List<Schedule> findLatenessHistoryByUserId(@Param("userId") Long userId);
 
     // 약속 히스토리 조회

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/UserSettingRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/UserSettingRepository.java
@@ -2,6 +2,8 @@ package devkor.ontime_back.repository;
 
 import devkor.ontime_back.entity.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,6 +11,11 @@ import java.util.UUID;
 
 @Repository
 public interface UserSettingRepository extends JpaRepository<UserSetting, UUID> {
-    Optional<UserSetting> findByUserId(Long userId);
+
+    // 페치조인 적용
+    @Query("SELECT us FROM UserSetting us JOIN FETCH us.user WHERE us.user.id = :userId")
+    Optional<UserSetting> findByUserId(@Param("userId") Long userId);
+
+
     Optional<UserSetting> findByUserSettingId(UUID userSettingId);
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
@@ -8,6 +8,8 @@ import devkor.ontime_back.dto.UserAdditionalInfoDto;
 import devkor.ontime_back.dto.UserSignUpDto;
 import devkor.ontime_back.entity.Role;
 import devkor.ontime_back.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
@@ -52,7 +54,7 @@ class UserAuthControllerTest extends ControllerTestSupport {
                 .role(Role.USER)
                 .build();
 
-        when(userAuthService.signUp(any(UserSignUpDto.class))).thenReturn(mockUser);
+        when(userAuthService.signUp(any(HttpServletRequest.class), any(HttpServletResponse.class),any(UserSignUpDto.class))).thenReturn(mockUser);
 
         // when // then
         mockMvc.perform(
@@ -64,36 +66,11 @@ class UserAuthControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.message").value("회원가입이 성공적으로 완료되었습니다. 추가 정보를 기입해주세요( {userId}/additional-info )"))
+                .andExpect(jsonPath("$.message").value("회원가입이 성공적으로 완료되었습니다. 온보딩을 진행해주세요( /user/onboarding )"))
                 .andExpect(jsonPath("$.data.userId").value(1));
      }
 
-     @DisplayName("(회원가입 직후) 추가 정보 기입에 성공한다")
-     @Test
-     void addInfo() throws Exception {
-         // given
-         UserAdditionalInfoDto userAdditionalInfoDto = UserAdditionalInfoDto.builder()
-                 .spareTime(10)
-                 .note("내 인생에 더 이상의 지각은 없다!!!")
-                 .build();
-
-         // 원래 addInfo는 User객체를 반환하지만 컨트롤러에서는 반환값을 사용하지 않으므로 null로 설정하였음.
-         when(userAuthService.addInfo(any(Long.class), any(UserAdditionalInfoDto.class))).thenReturn(null);
-
-         // when // then
-         mockMvc.perform(
-                        put("/1/additional-info")
-                                .content(objectMapper.writeValueAsString(userAdditionalInfoDto))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.message").value("추가 정보가 성공적으로 기입되었습니다!"));
-      }
-
-    @DisplayName("비밀번호 변경에 성공한다")
+    @DisplayName("비밀번호 변경에 성공한다.")
     @Test
     void changePassword() throws Exception {
         // given
@@ -119,7 +96,7 @@ class UserAuthControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("비밀번호가 성공적으로 변경되었습니다!"));
     }
 
-    @DisplayName("계정 삭제에 성공한다")
+    @DisplayName("계정 삭제에 성공한다.")
     @Test
     void deleteUser() throws Exception {
         // given

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/UserControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/UserControllerTest.java
@@ -2,9 +2,7 @@ package devkor.ontime_back.controller;
 
 import devkor.ontime_back.ControllerTestSupport;
 import devkor.ontime_back.TestSecurityConfig;
-import devkor.ontime_back.dto.ChangePasswordDto;
-import devkor.ontime_back.dto.UpdateSpareTimeDto;
-import devkor.ontime_back.dto.UserSignUpDto;
+import devkor.ontime_back.dto.*;
 import devkor.ontime_back.entity.Role;
 import devkor.ontime_back.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -12,10 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -88,6 +88,42 @@ class UserControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.status").value("success"))
                 .andExpect(jsonPath("$.message").value("사용자 여유시간이 성공적으로 업데이트되었습니다!"));
+    }
+
+    @DisplayName("(회원가입 직후) 온보딩에 성공한다.")
+    @Test
+    void onboarding() throws Exception {
+        // given
+        PreparationDto preparationDto1 = PreparationDto.builder()
+                .preparationId(UUID.randomUUID())
+                .preparationName("준비물")
+                .build();
+
+        PreparationDto preparationDto2 = PreparationDto.builder()
+                .preparationId(UUID.randomUUID())
+                .preparationName("준비물2")
+                .build();
+
+        UserOnboardingDto userOnboardingDto = UserOnboardingDto.builder()
+                .spareTime(10)
+                .note("안녕하세요")
+                .preparationList(List.of(new PreparationDto[]{preparationDto1, preparationDto2}))
+                .build();
+
+        when(userAuthService.getUserIdFromToken(any())).thenReturn(1L);
+        doNothing().when(userService).onboarding(any(Long.class), any(UserOnboardingDto.class));
+
+        // when // then
+        mockMvc.perform(
+                        put("/user/onboarding")
+                                .content(objectMapper.writeValueAsString(userOnboardingDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("온보딩이 성공적으로 완료되었습니다!"));
     }
 
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/service/UserAuthServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/UserAuthServiceTest.java
@@ -8,6 +8,9 @@ import devkor.ontime_back.entity.UserSetting;
 import devkor.ontime_back.repository.UserRepository;
 import devkor.ontime_back.repository.UserSettingRepository;
 import devkor.ontime_back.response.GeneralException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,6 +39,9 @@ class UserAuthServiceTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+    private ServletRequest httpServletRequest;
+    @Autowired
+    private HttpServletResponse httpServletResponse;
 
     @AfterEach
     void tearDown() {
@@ -50,7 +56,7 @@ class UserAuthServiceTest {
         UserSignUpDto userSignUpDto = getUserSignUpDto("user@example.com", "password1234", "junbeom", "a304cde3-8ee9-4054-971a-300aacc2177c");
 
         // when
-        User addedUser = userAuthService.signUp(userSignUpDto);
+        User addedUser = userAuthService.signUp((HttpServletRequest) httpServletRequest, httpServletResponse, userSignUpDto);
         UserSetting userSetting = addedUser.getUserSetting();
 
         // then
@@ -74,10 +80,10 @@ class UserAuthServiceTest {
         UserSignUpDto userSignUpDto2 = getUserSignUpDto("user@example.com", "password1234", "junbeom2", "a304cde3-8ee9-4054-971a-300aacc2177d");
 
         // when, then
-        User addedUser1 = userAuthService.signUp(userSignUpDto1);
+        User addedUser1 = userAuthService.signUp((HttpServletRequest) httpServletRequest, httpServletResponse,userSignUpDto1);
         assertThat(addedUser1.getId()).isNotNull();
 
-        assertThatThrownBy(() -> userAuthService.signUp(userSignUpDto2))
+        assertThatThrownBy(() -> userAuthService.signUp((HttpServletRequest) httpServletRequest, httpServletResponse,userSignUpDto2))
                 .isInstanceOf(GeneralException.class)
                 .hasMessage("이미 존재하는 이메일입니다.");
     }
@@ -91,10 +97,10 @@ class UserAuthServiceTest {
         UserSignUpDto userSignUpDto2 = getUserSignUpDto("user2@example.com", "password1234", "junbeom", "a304cde3-8ee9-4054-971a-300aacc2177d");
 
         // when, then
-        User addedUser1 = userAuthService.signUp(userSignUpDto1);
+        User addedUser1 = userAuthService.signUp((HttpServletRequest) httpServletRequest, httpServletResponse,userSignUpDto1);
         assertThat(addedUser1.getId()).isNotNull();
 
-        assertThatThrownBy(() -> userAuthService.signUp(userSignUpDto2))
+        assertThatThrownBy(() -> userAuthService.signUp((HttpServletRequest) httpServletRequest, httpServletResponse,userSignUpDto2))
                 .isInstanceOf(GeneralException.class)
                 .hasMessage("이미 존재하는 이름입니다.");
     }
@@ -108,10 +114,10 @@ class UserAuthServiceTest {
         UserSignUpDto userSignUpDto2 = getUserSignUpDto("user2@example.com", "password1234", "junbeom2", "a304cde3-8ee9-4054-971a-300aacc2177c");
 
         // when, then
-        User addedUser1 = userAuthService.signUp(userSignUpDto1);
+        User addedUser1 = userAuthService.signUp((HttpServletRequest) httpServletRequest, httpServletResponse,userSignUpDto1);
         assertThat(addedUser1.getId()).isNotNull();
 
-        assertThatThrownBy(() -> userAuthService.signUp(userSignUpDto2))
+        assertThatThrownBy(() -> userAuthService.signUp((HttpServletRequest) httpServletRequest, httpServletResponse,userSignUpDto2))
                 .isInstanceOf(GeneralException.class)
                 .hasMessage("이미 존재하는 userSettingId 입니다.");
     }

--- a/ontime-back/src/test/java/devkor/ontime_back/service/UserServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/UserServiceTest.java
@@ -1,6 +1,8 @@
 package devkor.ontime_back.service;
 
 import devkor.ontime_back.dto.UpdateSpareTimeDto;
+import devkor.ontime_back.dto.UserAdditionalInfoDto;
+import devkor.ontime_back.dto.UserOnboardingDto;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -8,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.NoSuchElementException;
@@ -16,6 +19,12 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 class UserServiceTest {


### PR DESCRIPTION
## 작성/수정한 코드
- (조준범이) 구현한 엔티티들에 대해 연관관계가 있다면 모두 지연로딩을 적용함
- 필요한 리포지토리 메서드의 경우 페치조인을 적용함
- 온보딩API를 만들며 깨졌던 테스트코드 수정 및 온보딩API 테스트 코드 작성 
- 지각히스토리 조회 API 성능 추가 개선

## 지각히스토리 조회 API 성능 추가 개선 결과
[성능 개선 전]
![image](https://github.com/user-attachments/assets/3a1f2145-3f89-43ec-ab13-6cdab26855db)
[성능 개선 후]
![image](https://github.com/user-attachments/assets/bdb8101a-d7aa-4339-9434-f1e59344d511)

**668ms -> 542ms** 로 약간의 성능개선

[성능 개선 방법]
- Scheudle엔티티에 user_id 인덱스, latnessTime 인덱스 생성
- 지각히스토리조회메서드에 (페치)조인 제거
(지각히스토리 조회 API 성능 개선을 위해 페치조인을 했었는데 해당
      메서드를 사용하는 서비스메서드에서 USER를 참조하지 않아서 페치조인을
      할 필요가 없다고 판단해 쿼리 수정함.)


## 확인해야할 사항
- 제가 구현하지 않은 API에 대해서는 아직 성능 개선 작업 진행하지 않았습니다!
