### PR TITLE
[Feat] 애플로그인 기능 추가

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/applelogin/AppleLoginService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/applelogin/AppleLoginService.java
@@ -1,0 +1,249 @@
+package devkor.ontime_back.applelogin;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devkor.ontime_back.dto.OAuthAppleUserDto;
+import devkor.ontime_back.entity.Role;
+import devkor.ontime_back.entity.SocialType;
+import devkor.ontime_back.entity.User;
+import devkor.ontime_back.global.jwt.JwtTokenProvider;
+import devkor.ontime_back.global.jwt.JwtUtils;
+import devkor.ontime_back.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleLoginService {
+
+    private static final String APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
+    private static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token";
+
+    @Value("${apple.client-id}")
+    private String clientId;
+
+    @Value("${apple.team.id}")
+    private String teamId;
+
+    @Value("${apple.login.key}")
+    private String keyId;
+    private static final String REDIRECT_URI = "https://ontime.devkor.club/oauth2/apple/callback";
+
+    @Value("${apple.client-secret}")
+    private String privateKeyPath;
+
+    private String issuer = "https://appleid.apple.com";
+
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private final JwtUtils jwtUtils;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public Authentication registerOrLogin(String identityToken, String authorizationCode, String fullName, HttpServletResponse response) throws Exception {
+        Claims tokenClaims = verifyIdentityToken(identityToken);
+        if (tokenClaims.getSubject() == null) {
+            throw new IllegalStateException("Apple 로그인 검증 실패");
+        }
+
+        String appleUserId = tokenClaims.getSubject();
+        String email = tokenClaims.get("email", String.class);
+        boolean isEmailVerified = Boolean.parseBoolean(tokenClaims.get("email_verified", String.class));
+
+        OAuthAppleUserDto oAuthAppleUserDto = new OAuthAppleUserDto(appleUserId, email, isEmailVerified, fullName);
+
+        // appleAccessToken, appleRefreshToken 반환
+        // String appleAccessToken = getAppleAccessTokenAndRefreshToken(authorizationCode).getAccessToken();
+        String appleRefreshToken = getAppleAccessTokenAndRefreshToken(authorizationCode).getRefreshToken();
+        boolean isRevoked = checkAppleLoginRevoked(appleRefreshToken);
+        if (isRevoked) {
+            throw new IllegalStateException("Apple 로그인 철회됨: 사용자가 로그인 연결을 해제함");
+        }
+
+        Optional<User> existingUser = userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, appleUserId);
+
+        if (existingUser.isPresent()) {
+            return handleLogin(existingUser.get(), response);
+        } else {
+            return handleRegister(oAuthAppleUserDto, response);
+        }
+    }
+
+    private Authentication handleLogin(User user, HttpServletResponse response) throws IOException {
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        jwtTokenProvider.updateRefreshToken(user.getEmail(), refreshToken);
+        jwtTokenProvider.sendAccessToken(response, accessToken);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String responseBody = String.format(
+                "{\"message\": \"%s\", \"role\": \"%s\"}",
+                user.getRole().name().equals("GUEST")
+                        ? "유저의 ROLE이 GUEST이므로 온보딩API를 호출해 온보딩을 진행해야합니다."
+                        : "로그인에 성공하였습니다.",
+                user.getRole().name()
+        );
+
+        response.getWriter().write(responseBody);
+        response.getWriter().flush();
+
+        return new UsernamePasswordAuthenticationToken(user, null, Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name())));
+    }
+
+    private Authentication handleRegister(OAuthAppleUserDto oAuthAppleUserDto, HttpServletResponse response) throws IOException {
+        User newUser = User.builder()
+                .socialType(SocialType.GOOGLE)
+                .socialId(oAuthAppleUserDto.getAppleUserId())
+                .email(oAuthAppleUserDto.getEmail())
+                .name(oAuthAppleUserDto.getFullName())
+                .role(Role.GUEST)
+                .build();
+
+        User savedUser = userRepository.save(newUser);
+
+        String accessToken = jwtTokenProvider.createAccessToken(newUser.getEmail(), newUser.getId());
+        jwtTokenProvider.sendAccessToken(response, accessToken);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String responseBody = String.format(
+                "{\"message\": \"%s\", \"role\": \"%s\"}",
+                "회원가입이 완료되었습니다. ROLE이 GUEST이므로 온보딩이 필요합니다.",
+                savedUser.getRole().name()
+        );
+
+        response.getWriter().write(responseBody);
+        response.getWriter().flush();
+
+        return new UsernamePasswordAuthenticationToken(newUser, null, Collections.singletonList(new SimpleGrantedAuthority(newUser.getRole().name())));
+    }
+
+    // identitytoken 검증
+    private Claims verifyIdentityToken(String identityToken) throws
+            Exception {
+        Map<String, String> headers = jwtUtils.parseHeaders(identityToken);
+        // apple publickey
+        ApplePublicKeyResponse applePublicKeyResponse = restTemplate.getForObject(APPLE_KEYS_URL, ApplePublicKeyResponse.class);
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKeyResponse);
+        // claim
+        Claims tokenClaims = jwtUtils.getTokenClaims(identityToken, publicKey);
+        // iss 확인
+        if (!issuer.equals(tokenClaims.getIssuer())) {
+            throw new IllegalArgumentException("Invalid JWT: Issuer mismatch. Expected: " + issuer);
+        }
+        // aud 확인
+        if (!clientId.equals(tokenClaims.getAudience())) {
+            throw new IllegalArgumentException("Invalid JWT: Audience mismatch. Expected: " + clientId);
+        }
+
+        return tokenClaims;
+    }
+
+    // apple 서버로부터 accesstoken, refreshtoken 발급
+    private AppleTokenResponse getAppleAccessTokenAndRefreshToken(String authCode) throws Exception {
+        // clientSecret
+        String clientSecret = generateClientSecret();
+
+        String requestBody = String.format(
+                "grant_type=authorization_code&code=%s&client_id=%s&client_secret=%s&redirect_uri=%s",
+                authCode, clientId, clientSecret, REDIRECT_URI);
+
+        JsonNode response = restTemplate.postForObject(APPLE_TOKEN_URL, requestBody, JsonNode.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.treeToValue(response, AppleTokenResponse.class);
+    }
+
+    // clientsecret 생성
+    private String generateClientSecret() throws Exception {
+
+        // Private Key
+        String privateKeyContent = new String(Files.readAllBytes(Paths.get(privateKeyPath)))
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+
+        byte[] keyBytes = java.util.Base64.getDecoder().decode(privateKeyContent);
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        KeyFactory kf = KeyFactory.getInstance("EC");
+        PrivateKey privateKey = kf.generatePrivate(spec);
+
+        // now
+        Date now = new Date();
+
+        // clientSecret
+        return Jwts.builder()
+                .setHeaderParam("alg", "ES256")
+                .setHeaderParam("kid", keyId)
+                .setIssuer(teamId)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + 3600000))
+                .setAudience("https://appleid.apple.com")
+                .setSubject(clientId)
+                .signWith(privateKey, SignatureAlgorithm.ES256)
+                .compact();
+    }
+
+    // Apple 로그인 철회 감지
+    public boolean checkAppleLoginRevoked(String appleRefreshToken) throws Exception {
+        String clientSecret = generateClientSecret();
+
+        String revokeUrl = "https://appleid.apple.com/auth/revoke";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        String requestBody = UriComponentsBuilder.newInstance()
+                .queryParam("client_id", clientId)
+                .queryParam("client_secret", clientSecret)
+                .queryParam("token", appleRefreshToken)
+                .queryParam("token_type_hint", "refresh_token")
+                .build()
+                .toString().substring(1);
+
+        HttpEntity<String> requestEntity = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    revokeUrl, HttpMethod.POST, requestEntity, String.class);
+
+            return response.getStatusCode() != HttpStatus.OK;
+        } catch (HttpClientErrorException e) {
+            return true;
+        }
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/applelogin/ApplePublicKey.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/applelogin/ApplePublicKey.java
@@ -1,0 +1,4 @@
+package devkor.ontime_back.applelogin;
+
+public record ApplePublicKey(String kty, String kid, String alg, String n, String e) {
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/applelogin/ApplePublicKeyGenerator.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/applelogin/ApplePublicKeyGenerator.java
@@ -1,0 +1,33 @@
+package devkor.ontime_back.applelogin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ApplePublicKeyGenerator {
+    public PublicKey generatePublicKey(Map<String, String> tokenHeaders,
+                                       ApplePublicKeyResponse applePublicKeys) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        ApplePublicKey publicKey = applePublicKeys.getMatchedKey(tokenHeaders.get("kid"),
+                tokenHeaders.get("alg"));
+        return getPublicKey(publicKey);
+    }
+    private PublicKey getPublicKey(ApplePublicKey publicKey)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(new BigInteger(1, nBytes),
+                new BigInteger(1, eBytes));
+        KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
+        return keyFactory.generatePublic(publicKeySpec);
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/applelogin/ApplePublicKeyResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/applelogin/ApplePublicKeyResponse.java
@@ -1,0 +1,12 @@
+package devkor.ontime_back.applelogin;
+
+import java.util.List;
+
+public record ApplePublicKeyResponse(List<ApplePublicKey> keys) {
+    public ApplePublicKey getMatchedKey(String kid, String alg) {
+        return keys.stream()
+                .filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid JWT: No matching Apple Public Key found"));
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/applelogin/AppleTokenResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/applelogin/AppleTokenResponse.java
@@ -1,0 +1,23 @@
+package devkor.ontime_back.applelogin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class AppleTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private String idToken;
+
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleLoginRequestDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleLoginRequestDto.java
@@ -1,0 +1,10 @@
+package devkor.ontime_back.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthAppleLoginRequestDto {
+    private String idToken;
+    private String authCode;
+    private String fullName;
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleUserDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleUserDto.java
@@ -1,0 +1,18 @@
+package devkor.ontime_back.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthAppleUserDto {
+    private String appleUserId;
+    private String email;
+    private boolean isEmailVerified;
+    private String fullName;
+
+    public OAuthAppleUserDto(String appleUserId, String email, boolean isEmailVerified, String fullName) {
+        this.appleUserId = appleUserId;
+        this.email = email;
+        this.isEmailVerified = isEmailVerified;
+        this.fullName = fullName;
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/SocialType.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/SocialType.java
@@ -1,5 +1,5 @@
 package devkor.ontime_back.entity;
 
 public enum SocialType {
-    KAKAO, NAVER, GOOGLE
+    KAKAO, APPLE, GOOGLE
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtUtils.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtUtils.java
@@ -1,0 +1,36 @@
+package devkor.ontime_back.global.jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class JwtUtils {
+
+    //JWT 헤더 파싱
+    public Map<String, String> parseHeaders(String token) throws JsonProcessingException {
+        String header = token.split("\\.")[0];
+        return new ObjectMapper().readValue(decodeHeader(header), Map.class);
+    }
+
+    // JWT 헤더 디코딩
+    public String decodeHeader(String token) {
+        return new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+    }
+
+    //JWT Claims (페이로드) 파싱
+    public Claims getTokenClaims(String token, PublicKey publicKey) {
+        return Jwts.parserBuilder()
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}


### PR DESCRIPTION
**Identity token**
- ID 토큰 검증을 통해 얻는 사용자 정보 
- ID 토큰을 검증하기 위해 수행할 작업
    1. 토큰을 앱 서버로 안전하게 전송
        - 모바일 앱(네이티브) 또는 웹 앱에서 Apple 로그인 후, 서버로 ID 토큰을 전달
    2. JWT(JSON Web Token) 서명 검증
        - Apple 서버의 공개 키(Public Key) 를 사용하여 서명을 검증
        - Apple은 JWS E256 알고리즘을 사용하여 서명
    3. Nonce 검증
        - 요청할 때 사용한 nonce 값을 검증하여 재사용 공격(Replay Attack) 을 방지
    4. 토큰 필드 값 검증
        - iss(발급자) 값이 https://appleid.apple.com/ 인지 확인
        - aud(대상자) 값이 개발자 계정의 client_id 와 일치하는지 확인
        - 현재 시간이 exp(토큰 만료 시간)보다 이전인지 확인
        
 **Authorization Code**
- apple server에서 제공하는 accesstoken, refreshtoken 발급받을때 필요
- 애플로그인 철회 감지를 위해 refreshtoken을 통해 확인

**추가한 Controller**
POST /apple/registerOrLogin
Request Body: 
{
"idToken" : "dsafsdfa", 
"authCode" : "sdafsdfa",
"fullName" : "name"
}

**프론트측과 확인해야할 부분**
- idToken, authCode와 최초 로그인시 전달되는 fullName을 프론트측으로부터 받아야함
- idToken, authCode는 프론트측에서 Apple 로그인 UI를 거쳐야 하므로 Postman에서 직접 받을 수가 없어 테스트 불가
-> 프론트측에서 구현 후 테스트 예정


참고: https://developer.apple.com/documentation/sign_in_with_apple/authenticating-users-with-sign-in-with-apple

