### PR TITLE
[Feat] 애플로그인 회원탈퇴 구현

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleRequestDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleRequestDto.java
@@ -7,4 +7,5 @@ public class OAuthAppleRequestDto {
     private String idToken;
     private String authCode;
     private String fullName;
+    private String email;
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginFilter.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginFilter.java
@@ -72,17 +72,17 @@ public class AppleLoginFilter extends AbstractAuthenticationProcessingFilter {
             log.info("appleUserId: {}", appleUserId);
             String email = tokenClaims.get("email", String.class);
 
-            String appleRefreshToken = appleLoginService.getAppleAccessTokenAndRefreshToken(oAuthAppleRequestDto.getAuthCode()).getRefreshToken();
             // socialRefreshtoken에 저장
+            String appleRefreshToken = appleLoginService.getAppleAccessTokenAndRefreshToken(oAuthAppleRequestDto.getAuthCode()).getRefreshToken();
 
-            OAuthAppleUserDto oAuthAppleUserDto = new OAuthAppleUserDto(appleUserId, email, oAuthAppleRequestDto.getFullName());
+            OAuthAppleUserDto oAuthAppleUserDto = new OAuthAppleUserDto(appleUserId, oAuthAppleRequestDto.getEmail(), oAuthAppleRequestDto.getFullName());
 
             Optional<User> existingUser = userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, appleUserId);
 
             if (existingUser.isPresent()) {
-                return appleLoginService.handleLogin(existingUser.get(), response);
+                return appleLoginService.handleLogin(appleRefreshToken, existingUser.get(), response);
             } else {
-                return appleLoginService.handleRegister(oAuthAppleUserDto, response);
+                return appleLoginService.handleRegister(appleRefreshToken, oAuthAppleUserDto, response);
             }
 
         } catch (Exception e) {
@@ -92,3 +92,4 @@ public class AppleLoginFilter extends AbstractAuthenticationProcessingFilter {
     }
 
 }
+


### PR DESCRIPTION
### 소셜 로그인 회원탈퇴 

revokeToken을 위해,
애플 로그인: https://appleid.apple.com/auth/revoke 주소로 refreshToken 전달
구글 로그인: https://oauth2.googleapis.com/revoke? 주소로 refreshToken 전달

-> 서비스내에서는 서비스 자체 jwt를 사용할 예정이라 
이를 위해서 각 인증서버에서 제공하는 refreshToken을 따로 db에 저장하고 있어야함.

User entity에 socialLoginToken을 추가하고
회원탈퇴를 할 경우, user accesstoken을 통해 socialLoginToken을 불러온 후, revokeToken 진행 후 db에서 사용자 삭제함.

애플로그인 회원탈퇴 (완), 구글로그인은 프론트측에서 refreshToken을 받은 후 다시 테스트 예정