### PR TITLE
[mod] 유저 하드삭제시 준비과정의 nextPreparation필드 null로 초기화 하고 cascade삭제되게 설정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
@@ -3,7 +3,9 @@ package devkor.ontime_back.repository;
 import devkor.ontime_back.entity.PreparationUser;
 import devkor.ontime_back.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,4 +22,8 @@ public interface PreparationUserRepository extends JpaRepository<PreparationUser
     Optional<PreparationUser> findFirstPreparationUserByUser(User user);
 
     void deleteByUser(User user); // 메서드 선언
+
+    @Modifying
+    @Query("UPDATE PreparationUser p SET p.nextPreparation = NULL WHERE p.user.id = :userId")
+    void clearNextPreparationByUserId(@Param("userId") Long userId);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
@@ -7,6 +7,7 @@ import devkor.ontime_back.dto.UserSignUpDto;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.entity.UserSetting;
 import devkor.ontime_back.global.jwt.JwtTokenProvider;
+import devkor.ontime_back.repository.PreparationUserRepository;
 import devkor.ontime_back.repository.UserRepository;
 import devkor.ontime_back.entity.Role;
 import devkor.ontime_back.repository.UserSettingRepository;
@@ -31,6 +32,7 @@ public class UserAuthService {
 
     private final UserRepository userRepository;
     private final UserSettingRepository userSettingRepository;
+    private final PreparationUserRepository preparationUserRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -128,6 +130,7 @@ public class UserAuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
+        preparationUserRepository.clearNextPreparationByUserId(userId);
         userRepository.delete(user);
 
         return userId;


### PR DESCRIPTION
## 수정한 코드
- 유저 하드삭제 시 준비과정의 nextPreparation필드 null로 초기화 하고 cascade삭제되게 설정하였음.
   (프로덕션 서버에서 유저 하드삭제시 nextPreparation필드가 외래키 제한조건에 걸려 preparatiob_user데이터가 삭제되지 않아 오류가 발생했었음)

## 확인해야할 사항
- 프로덕션 서버에서 테스트를 해본 것은 아니여서 프로덕션 서버에서 동작한다는 보장이 없음.
- 개발서버에서는 코드 수정전에도 동작한 것으로 보아, 프로덕션서버와 개발서버간의 db설정에 차이가 있다거나 하는 가능성이 있어 차후 확인해봐야할 것 같음.