### PR TITLE
[mod] 유저 삭제시 유저준비과정 데이터 삭제방법 변경

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
@@ -7,6 +7,7 @@ import devkor.ontime_back.dto.UserSignUpDto;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.entity.UserSetting;
 import devkor.ontime_back.global.jwt.JwtTokenProvider;
+import devkor.ontime_back.repository.PreparationScheduleRepository;
 import devkor.ontime_back.repository.PreparationUserRepository;
 import devkor.ontime_back.repository.UserRepository;
 import devkor.ontime_back.entity.Role;
@@ -35,6 +36,7 @@ public class UserAuthService {
     private final PreparationUserRepository preparationUserRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final PreparationScheduleRepository preparationScheduleRepository;
 
     // 엑세스토큰에서 UserId 추출
     public Long getUserIdFromToken(HttpServletRequest request) {
@@ -130,7 +132,8 @@ public class UserAuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
-        preparationUserRepository.clearNextPreparationByUserId(userId);
+//        preparationUserRepository.clearNextPreparationByUserId(userId);
+
         userRepository.delete(user);
 
         return userId;


### PR DESCRIPTION
## 수정한 코드
- **(수정 전)** 유저삭제API호출 시 유저를 삭제하는 메서드를 실행시키기 전 유저준비과정의 nextPreparation필드를 모두 NULL로 초기화 한 뒤 유저 삭제 메서드를 실행했음.
- **(수정 후)** 위 코드를 삭제하고, **DB에 CASCADE옵션**을 넣어서 자동삭제되게 설정. 
(유저 준비과정뿐만 아니라 약속 준비과정에도 CASCADE 옵션 넣었음. schedule삭제할 때 약속준비과정이 schedule참조하고 있어서 schedule이 삭제가 안되는 오류가 발생했었음.)

## 확인해야할 사항
- 기존 방법은 스프링 서버에서 DB 서버로 **여러번의 쿼리**를 날려야했음.
- 수정 후의 방법은 **한방의 쿼리**가 날아가고 DB에서 연관된 테이블을 모두 삭제시키기 때문에 **성능적으로 더 우수**함.

## 제안할 사항
### spring.jpa.hibernate.ddl-auto 옵션 **update -> validate**로 변경
- 트러블 슈팅을 하면서 운영서버의 application.properties를 확인하였는데 spring-ddl-auto 옵션이 update로 돼있는 것을 확인할 수 있었음. 운영서버에서 해당 옵션을 update로 설정하는 것은 지양해야함. (예: 기존에 데이터가 있는 테이블에 not null인 필드를 추가하면, 기존 데이터가 삽입이 안되는 치명적 오류가 발생할 수 있음) 
- 따라서 **ddl-auto 옵션을 update -> validate로 변경**하는 것을 제안드립니다.
- (References) 
https://colabear754.tistory.com/136#update
https://smpark1020.tistory.com/140
https://velog.io/@kevin_/%EB%82%B4%EA%B0%80-ddl-auto%EB%A5%BC-update%EB%A1%9C-%ED%96%88%EB%8D%98-%EC%9D%B4%EC%9C%A0%EC%99%80-%ED%8C%A8%EC%B0%A9
