### PR TITLE
[mod] PreparationSchedule 엔티티 필드명 및 연관관계 수정, @Transactional

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/entity/PreparationSchedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/PreparationSchedule.java
@@ -1,19 +1,19 @@
 package devkor.ontime_back.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Time;
 import java.util.UUID;
 
 @Getter
 @Entity
 @NoArgsConstructor
+@Builder
 public class PreparationSchedule {
     @Id
-    private UUID preparationId;
+    private UUID preparationScheduleId;
 
     @ManyToOne
     @JoinColumn(name = "schedule_id", nullable = false)
@@ -24,13 +24,12 @@ public class PreparationSchedule {
 
     private Integer preparationTime;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "next_preparation_id")
     private PreparationSchedule nextPreparation;
 
-
-    public PreparationSchedule(UUID preparationId, Schedule schedule, String preparationName, Integer preparationTime, PreparationSchedule preparationSchedule) {
-        this.preparationId = preparationId;
+    public PreparationSchedule(UUID preparationScheduleId, Schedule schedule, String preparationName, Integer preparationTime, PreparationSchedule preparationSchedule) {
+        this.preparationScheduleId = preparationScheduleId;
         this.schedule = schedule;
         this.preparationName = preparationName;
         this.preparationTime = preparationTime;

--- a/ontime-back/src/main/java/devkor/ontime_back/service/PreparationScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/PreparationScheduleService.java
@@ -2,17 +2,13 @@ package devkor.ontime_back.service;
 
 import devkor.ontime_back.dto.PreparationDto;
 import devkor.ontime_back.entity.PreparationSchedule;
-import devkor.ontime_back.entity.PreparationUser;
 import devkor.ontime_back.entity.Schedule;
-import devkor.ontime_back.entity.User;
 import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.repository.PreparationScheduleRepository;
-import devkor.ontime_back.repository.PreparationUserRepository;
 import devkor.ontime_back.repository.ScheduleRepository;
 import devkor.ontime_back.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,7 +19,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PreparationScheduleService {
     private final PreparationScheduleRepository preparationScheduleRepository;
@@ -36,15 +32,18 @@ public class PreparationScheduleService {
         return jwtTokenProvider.extractUserId(accessToken).orElseThrow(() -> new RuntimeException("User ID not found in token"));
     }
 
+    @Transactional
     public void makePreparationSchedules(Long userId, UUID scheduleId, List<PreparationDto> preparationDtoList) {
         handlePreparationSchedules(userId, scheduleId, preparationDtoList, false);
     }
 
+    @Transactional
     public void updatePreparationSchedules(Long userId, UUID scheduleId, List<PreparationDto> preparationDtoList) {
         handlePreparationSchedules(userId, scheduleId, preparationDtoList, true);
     }
 
-    private void handlePreparationSchedules(Long userId, UUID scheduleId, List<PreparationDto> preparationDtoList, boolean shouldDelete) {
+    @Transactional
+    protected void handlePreparationSchedules(Long userId, UUID scheduleId, List<PreparationDto> preparationDtoList, boolean shouldDelete) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new IllegalArgumentException("Schedule not found with id: " + scheduleId));
 

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -18,7 +18,6 @@ import jakarta.servlet.http.HttpServletRequest;
 
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -180,11 +179,11 @@ public class ScheduleService {
         if (Boolean.TRUE.equals(schedule.getIsChange())) {
             return preparationScheduleRepository.findBySchedule(schedule).stream()
                     .map(preparationSchedule -> new PreparationDto(
-                            preparationSchedule.getPreparationId(),
+                            preparationSchedule.getPreparationScheduleId(),
                             preparationSchedule.getPreparationName(),
                             preparationSchedule.getPreparationTime(),
                             preparationSchedule.getNextPreparation() != null
-                                    ? preparationSchedule.getNextPreparation().getPreparationId()
+                                    ? preparationSchedule.getNextPreparation().getPreparationScheduleId()
                                     : null
                     ))
                     .collect(Collectors.toList());


### PR DESCRIPTION
## 수정한 코드
- PreparationSchedule엔티티의 필드 preparationId -> preparationScheduleId으로 수정
- PreparationSchedule엔티티의 필드 nextPreparation @ManyToOne -> @OneToOne으로 수정
- PreparationScheduleService 클래스에 Transactional(ReadOnly=True)걸고, 내부 메서드 중 CUD가 필요한 메서드에 Transactional을 추가로 걸었음

## 확인해야할 사항
- PreparationSchedule 조회 API를 만들다 80%이상 완성하고 호출URL 네이밍하는 와중 Swagger확인하면서 해당API가 이미 존재하는 것을 확인하였습니다.
- 따라서 작업한 내용 전부 없애고 작업 도중 수행한 리팩토링만 PUSH합니다.

## Issue Close
close #98 