### PR TITLE
[Mod] preparation 조회 API 및 preparation 관련 메서드 성능 개선

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationUserController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationUserController.java
@@ -25,32 +25,6 @@ public class PreparationUserController {
 
     private final PreparationUserService preparationUserService;
 
-
-//    @Operation(
-//            summary = "사용자 준비과정 첫 세팅",
-//            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-//                    description = "사용자 준비과정 관련 JSON 데이터",
-//                    required = true,
-//                    content = @Content(
-//                            schema = @Schema(
-//                                    type = "object",
-//                                    example = "[\n {\n \"preparationId\": \"123e4567-e89b-12d3-a456-426614174011\",\n \"preparationName\": \"Step 1: Wake up\",\n \"preparationTime\": 5,\n \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174012\"\n },\n {\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174012\",\n\"preparationName\": \"Step 2: Brush teeth\",\n \"preparationTime\": 15,\n \"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174013\"\n },\n {\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174013\",\n\"preparationName\": \"Step 3: Wearing Clothes\",\n\"preparationTime\": 15,\n\"nextPreparationId\": \"123e4567-e89b-12d3-a456-426614174014\"\n },\n{\n\"preparationId\": \"123e4567-e89b-12d3-a456-426614174014\",\n\"preparationName\": \"Step 4: Breakfast\",\n\"preparationTime\": 30,\n\"nextPreparationId\": null\n }\n ]"
-//                            )
-//                    )
-//            )
-//    )
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "사용자 준비과정 세팅 완료", content = @Content(mediaType = "application/json", schema = @Schema(example = "{\n\"status\": \"success\",\n \"code\": \"200\",\n \"message\": \"OK\",\n \"data\": null\n }"))),
-//            @ApiResponse(responseCode = "4XX", description = "잘못된 요청", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
-//    })
-//    @PostMapping("/set/first")
-//    public ResponseEntity<ApiResponseForm<Void>> setFirstPreparationUser(HttpServletRequest request, @RequestBody List<PreparationDto> preparationDtoList) {
-//        Long userId = preparationUserService.getUserIdFromToken(request);
-//
-//        preparationUserService.setFirstPreparationUser(userId, preparationDtoList);
-//        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseForm.success(null));
-//    }
-
     @Operation(
             summary = "사용자 준비과정 수정",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/PreparationSchedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/PreparationSchedule.java
@@ -15,7 +15,7 @@ public class PreparationSchedule {
     @Id
     private UUID preparationScheduleId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id", nullable = false)
     private Schedule schedule;
 
@@ -24,7 +24,7 @@ public class PreparationSchedule {
 
     private Integer preparationTime;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "next_preparation_id")
     private PreparationSchedule nextPreparation;
 

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/PreparationUser.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/PreparationUser.java
@@ -17,7 +17,7 @@ public class PreparationUser {
     @Id
     private UUID preparationId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
@@ -27,7 +27,7 @@ public class PreparationUser {
 
     private Integer preparationTime;
 
-    @ManyToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "next_preparation_id")
     private PreparationUser nextPreparation;
 

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationScheduleRepository.java
@@ -4,6 +4,8 @@ import devkor.ontime_back.entity.PreparationSchedule;
 import devkor.ontime_back.entity.Schedule;
 import devkor.ontime_back.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,6 +13,11 @@ import java.util.UUID;
 
 @Repository
 public interface PreparationScheduleRepository extends JpaRepository<PreparationSchedule, UUID> {
-    List<PreparationSchedule> findBySchedule(Schedule schedule);
-    void deleteBySchedule(Schedule schedule); // 메서드 선언
+
+    @Query("SELECT ps FROM PreparationSchedule ps " +
+            "LEFT JOIN FETCH ps.nextPreparation " +
+            "WHERE ps.schedule = :schedule")
+    List<PreparationSchedule> findByScheduleWithNextPreparation(@Param("schedule") Schedule schedule);
+
+    void deleteBySchedule(Schedule schedule);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
@@ -15,13 +15,19 @@ import java.util.UUID;
 @Repository
 public interface PreparationUserRepository extends JpaRepository<PreparationUser, UUID> {
 
-    List<PreparationUser> findByUser(User user);
+    // user 객체를 생성하는 대신, userId로 preparationUser 가져오는 메서드 생성
+    @Query("SELECT pu FROM PreparationUser pu " +
+            "LEFT JOIN FETCH pu.nextPreparation " +
+            "WHERE pu.user.id = :userId")
+    List<PreparationUser> findByUserIdWithNextPreparation(@Param("userId") Long userId);
 
-    @Query("SELECT pu FROM PreparationUser pu WHERE pu.user = :user AND pu NOT IN " +
-            "(SELECT p.nextPreparation FROM PreparationUser p WHERE p.nextPreparation IS NOT NULL)")
-    Optional<PreparationUser> findFirstPreparationUserByUser(User user);
+    @Query("SELECT pu FROM PreparationUser pu " +
+            "LEFT JOIN FETCH pu.nextPreparation " +
+            "WHERE pu.user.id = :userId " +
+            "AND pu NOT IN (SELECT p.nextPreparation FROM PreparationUser p WHERE p.nextPreparation IS NOT NULL)")
+    Optional<PreparationUser> findFirstPreparationUserByUserIdWithNextPreparation(@Param("userId") Long userId);
 
-    void deleteByUser(User user); // 메서드 선언
+    void deleteByUser(User user);
 
     @Modifying
     @Query("UPDATE PreparationUser p SET p.nextPreparation = NULL WHERE p.user.id = :userId")

--- a/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
@@ -26,13 +26,13 @@ public class PreparationUserService {
 
     public Long getUserIdFromToken(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization").substring(7); // "Bearer "를 제외한 토큰
-        return jwtTokenProvider.extractUserId(accessToken).orElseThrow(() -> new RuntimeException("User ID not found in token"));
+        return jwtTokenProvider.extractUserId(accessToken).orElseThrow(() -> new RuntimeException("토큰에서 사용자 ID를 찾을 수 없습니다."));
     }
 
     // 회원가입 시 디폴트 준비과정 세팅
     public void setFirstPreparationUser(Long userId, List<PreparationDto> preparationDtoList) {
         User user = userRepository.findById(userId).orElseThrow(() ->
-                new EntityNotFoundException("User with ID " + userId + " not found.")
+                new EntityNotFoundException("사용자 ID " + userId + "에 해당하는 사용자를 찾을 수 없습니다.")
         );
         handlePreparationUsers(user, preparationDtoList, false);
 
@@ -41,9 +41,8 @@ public class PreparationUserService {
     // 준비과정 수정
     @Transactional
     public void updatePreparationUsers(Long userId, List<PreparationDto> preparationDtoList) {
-        // user 확인
         User user = userRepository.findById(userId).orElseThrow(() ->
-                new EntityNotFoundException("User with ID " + userId + " not found.")
+                new EntityNotFoundException("사용자 ID " + userId + "에 해당하는 사용자를 찾을 수 없습니다.")
         );
         handlePreparationUsers(user, preparationDtoList, true);
 
@@ -51,13 +50,9 @@ public class PreparationUserService {
 
     // 준비과정 불러오기
     public List<PreparationDto> showAllPreparationUsers(Long userId) {
-        // user 확인
-        User user = userRepository.findById(userId).orElseThrow(() ->
-                new EntityNotFoundException("User with ID " + userId + " not found.")
-        );
 
-        PreparationUser firstPreparation = preparationUserRepository.findFirstPreparationUserByUser(user)
-                .orElseThrow(() -> new EntityNotFoundException("No starting PreparationUser found for User ID: " + userId));
+        PreparationUser firstPreparation = preparationUserRepository.findFirstPreparationUserByUserIdWithNextPreparation(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자 ID " + userId + "에 대한 시작 준비 단계를 찾을 수 없습니다."));
 
         List<PreparationDto> preparationDtos = new ArrayList<>();
         PreparationUser current = firstPreparation;

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -40,7 +40,7 @@ public class ScheduleService {
     // userId 추출
     public Long getUserIdFromToken(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization").substring(7); // "Bearer "를 제외한 토큰
-        return jwtTokenProvider.extractUserId(accessToken).orElseThrow(() -> new RuntimeException("token에서 userId가 추출되지 않습니다."));
+        return jwtTokenProvider.extractUserId(accessToken).orElseThrow(() -> new RuntimeException("토큰에서 사용자 ID를 찾을 수 없습니다."));
     }
 
     // scheduleId, userId를 통한 권한 확인
@@ -177,7 +177,7 @@ public class ScheduleService {
         Schedule schedule = getScheduleWithAuthorization(scheduleId, userId);
 
         if (Boolean.TRUE.equals(schedule.getIsChange())) {
-            return preparationScheduleRepository.findBySchedule(schedule).stream()
+            return preparationScheduleRepository.findByScheduleWithNextPreparation(schedule).stream()
                     .map(preparationSchedule -> new PreparationDto(
                             preparationSchedule.getPreparationScheduleId(),
                             preparationSchedule.getPreparationName(),
@@ -188,7 +188,7 @@ public class ScheduleService {
                     ))
                     .collect(Collectors.toList());
         } else {
-            return preparationUserRepository.findByUser(schedule.getUser()).stream()
+            return preparationUserRepository.findByUserIdWithNextPreparation(schedule.getUser().getId()).stream()
                     .map(preparationUser -> new PreparationDto(
                             preparationUser.getPreparationId(),
                             preparationUser.getPreparationName(),


### PR DESCRIPTION
## 추가한 코드
- preparationSchedule: @ManyToOne 관계인 schedule과 @OneToOne 관계인 nextPreparation에 `(fetch = FetchType.LAZY)` 설정 적용
- preparationUser: @ManyToOne 관계인 user와 @OneToOne 관계인 nextPreparation에 `(fetch = FetchType.LAZY)` 설정 적용
- `findByScheduleWithNextPreparation`, `findByUserIdWithNextPreparation`, `findFirstPreparationUserByUserIdWithNextPreparation` 메서드에서 한 번의 쿼리로 PreparationSchedule과 nextPreparation을 함께 로딩하여 성능을 최적화
- 각종 예외 메시지 한글로 수정

## 알게된 내용

### @OneToOne 관계에서 Lazy Loading 한계
- Hibernate는 프록시 객체를 만들 때 연관된 객체가 없을 수 있다는 점을 고려
- `@ManyToOne`, `@OneToMany` - 연관된 객체가 없는 경우라도 “컬렉션(empty collection)“이라는 빈 객체가 명확히 존재
-> 별도 쿼리를 하지 않고 지연로딩 프록시를 쉽게 만듦
- `@OneToOne` 관계 - 연관된 객체가 없으면 NULL
-> NULL 여부를 알기 위해 추가 SELECT 쿼리를 즉시 실행할 가능성 존재

### @OneToOne의 Lazy Loading vs @ManyToOne의 Lazy Loading
- @ManyToOne - 연관된 엔티티의 ID가 존재하므로, JPA는 이 ID를 이용해서 프록시 객체를 만들 수 있음
- @OneToOne - FK가 있는 주 엔티티는 Lazy Loading이 가능, FK가 없는 연관 엔티티에서는 Lazy Loading이 Eager Loading처럼 작동 가능
-> preparationSchedule, preparationUser 모두 셀프참조이며 FK가 설정되어있음

**해결방법**)
Fetch Join - Hibernate가 추가 쿼리를 실행할 필요 없이 한 번에 가져옴
(optional = false 설정 - Hibernate가 프록시 객체를 활용할 수 있도록 유도) -> null인 값이 있기 때문에 사용 불가

## preparation 조회 API 성능 개선
### Before
**(2.58s)**
![image](https://github.com/user-attachments/assets/f76734cc-9f93-4119-9888-ce1f69706ca4)

### After
**(767ms)**
![image](https://github.com/user-attachments/assets/fbc3a301-6a91-4fd0-97c4-d158ad5f9893)

close #100 