### PR TITLE
[Mod] preparationUser api 테스트코드 작성

### DIFF
--- a/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
@@ -1,16 +1,10 @@
 package devkor.ontime_back;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import devkor.ontime_back.controller.FriendShipController;
-import devkor.ontime_back.controller.ScheduleController;
-import devkor.ontime_back.controller.UserAuthController;
-import devkor.ontime_back.controller.UserController;
+import devkor.ontime_back.controller.*;
 import devkor.ontime_back.global.generallogin.handler.LoginSuccessHandler;
 import devkor.ontime_back.repository.UserRepository;
-import devkor.ontime_back.service.FriendshipService;
-import devkor.ontime_back.service.ScheduleService;
-import devkor.ontime_back.service.UserAuthService;
-import devkor.ontime_back.service.UserService;
+import devkor.ontime_back.service.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -22,7 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
                 UserAuthController.class,
                 UserController.class,
                 ScheduleController.class,
-                FriendShipController.class
+                FriendShipController.class,
+                PreparationUserController.class
         }
 )
 public abstract class ControllerTestSupport {
@@ -44,6 +39,9 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected FriendshipService friendshipService;
+
+    @MockBean
+    protected PreparationUserService preparationUserService;
 
     @MockBean
     protected UserRepository userRepository;

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/PreparationUserControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/PreparationUserControllerTest.java
@@ -1,0 +1,97 @@
+package devkor.ontime_back.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devkor.ontime_back.ControllerTestSupport;
+import devkor.ontime_back.TestSecurityConfig;
+import devkor.ontime_back.dto.PreparationDto;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestSecurityConfig.class)
+public class PreparationUserControllerTest extends ControllerTestSupport {
+
+    @Test
+    @DisplayName("준비과정 수정에 성공한다.")
+    void modifyPreparationUser_success() throws Exception {
+        // given
+        Long userId = 1L;
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+
+        // when & then
+        mockMvc.perform(post("/preparationuser/modify")
+                        .header("Authorization", "Bearer test-token")
+                        .content(objectMapper.writeValueAsString(preparationDtoList))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("OK"));
+
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(preparationUserService, times(1))
+                .updatePreparationUsers(eq(userId), argThat(list -> list.size() == preparationDtoList.size()));
+    }
+
+
+    @Test
+    @DisplayName("준비과정 조회 요청에 성공한다.")
+    void getAllPreparationUser_success() throws Exception {
+        // given
+        Long userId = 1L;
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(preparationUserService.showAllPreparationUsers(userId)).thenReturn(preparationDtoList);
+
+        // when & then
+        mockMvc.perform(get("/preparationuser/show/all")
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].preparationId").value(preparationUser1Id.toString()))
+                .andExpect(jsonPath("$.data[0].preparationName").value("세면"))
+                .andExpect(jsonPath("$.data[1].preparationId").value(preparationUser2Id.toString()))
+                .andExpect(jsonPath("$.data[1].preparationName").value("옷입기"));
+
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(preparationUserService, times(1)).showAllPreparationUsers(userId);
+    }
+
+
+}

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/ScheduleControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/ScheduleControllerTest.java
@@ -9,8 +9,6 @@ import devkor.ontime_back.dto.*;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 
@@ -19,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -48,7 +45,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 new ScheduleDto(UUID.randomUUID(), new PlaceDto(UUID.randomUUID(), "과학도서관"), "공부하기", 10, startDate, 5, "늦으면 안됨", 2),
                 new ScheduleDto(UUID.randomUUID(), new PlaceDto(UUID.randomUUID(), "중식당"), "가족행사", 15, startDate.plusHours(2), 10, "생신", 0)
         );
-        when(scheduleService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
         when(scheduleService.showSchedulesByPeriod(userId, startDate, endDate)).thenReturn(mockSchedules);
 
         // when & then
@@ -65,7 +62,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data[1].scheduleName").value("가족행사"))
                 .andDo(print());
 
-        verify(scheduleService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
         verify(scheduleService, times(1)).showSchedulesByPeriod(userId, startDate, endDate);
 
     }
@@ -79,7 +76,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
 
         ScheduleDto mockSchedule = new ScheduleDto(scheduleId, new PlaceDto(UUID.randomUUID(), "과학도서관"), "공부하기", 10, LocalDateTime.of(2024, 11, 15, 18, 0), 5, "늦으면 안됨", 2);
 
-        when(scheduleService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
         when(scheduleService.showScheduleByScheduleId(userId, scheduleId)).thenReturn(mockSchedule);
 
         // when & then
@@ -95,7 +92,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.scheduleName").value("공부하기"))
                 .andDo(print());
 
-        verify(scheduleService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
         verify(scheduleService, times(1)).showScheduleByScheduleId(userId, scheduleId);
     }
 
@@ -106,7 +103,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
         UUID scheduleId = UUID.randomUUID();
         Long userId = 1L;
 
-        when(scheduleService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
         doNothing().when(scheduleService).deleteSchedule(scheduleId, userId);
 
         // when & then
@@ -119,7 +116,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andDo(print());
 
-        verify(scheduleService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
         verify(scheduleService, times(1)).deleteSchedule(scheduleId, userId);
     }
 
@@ -141,7 +138,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 "점심 식단 확인하자."
         );
 
-        when(scheduleService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
         doNothing().when(scheduleService).modifySchedule(userId, scheduleModDto);
 
         // when & then
@@ -155,7 +152,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andDo(print());
 
-        verify(scheduleService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
         verify(scheduleService, times(1)).modifySchedule(eq(userId), any(ScheduleModDto.class));
     }
 
@@ -179,7 +176,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 "늦으면 안됨"
         );
 
-        when(scheduleService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
         doNothing().when(scheduleService).addSchedule(scheduleAddDto, userId);
 
         // when & then
@@ -193,7 +190,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andDo(print());
 
-        verify(scheduleService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
         verify(scheduleService, times(1)).addSchedule(any(ScheduleAddDto.class), eq(userId));
     }
 
@@ -204,7 +201,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
         UUID scheduleId = UUID.randomUUID();
         Long userId = 1L;
 
-        when(scheduleService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
         doNothing().when(scheduleService).checkIsStarted(scheduleId, userId);
 
         // when & then
@@ -217,7 +214,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andDo(print());
 
-        verify(scheduleService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
         verify(scheduleService, times(1)).checkIsStarted(scheduleId, userId);
     }
 
@@ -235,7 +232,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 new PreparationDto(preparationId2, "화장", 5, null)
         );
 
-        when(scheduleService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
         when(scheduleService.getPreparations(userId, scheduleId)).thenReturn(mockPreparations);
 
         // when & then
@@ -250,7 +247,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data[1].preparationName").value("화장"))
                 .andDo(print());
 
-        verify(scheduleService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
         verify(scheduleService, times(1)).getPreparations(userId, scheduleId);
     }
 

--- a/ontime-back/src/test/java/devkor/ontime_back/service/PreparationUserServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/PreparationUserServiceTest.java
@@ -183,9 +183,6 @@ public class PreparationUserServiceTest {
                 preparationUser2Id, newUser, "아침식사", 10, preparationUser3));
         PreparationUser preparationUser1= preparationUserRepository.save(new PreparationUser(
                 preparationUser1Id, newUser, "세면", 10, preparationUser2));
-        preparationUserRepository.save(preparationUser1);
-        preparationUserRepository.save(preparationUser2);
-        preparationUserRepository.save(preparationUser3);
 
         // when
         List<PreparationDto> result = preparationUserService.showAllPreparationUsers(newUser.getId());
@@ -278,9 +275,6 @@ public class PreparationUserServiceTest {
                 UUID.randomUUID(), newUser, "아침식사", 10, preparationUser3));
         PreparationUser preparationUser1= preparationUserRepository.save(new PreparationUser(
                 UUID.randomUUID(), newUser, "알림확인", 10, preparationUser2));
-        preparationUserRepository.save(preparationUser1);
-        preparationUserRepository.save(preparationUser2);
-        preparationUserRepository.save(preparationUser3);
 
         List<PreparationDto> preparationDtoList = List.of(
                 new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),

--- a/ontime-back/src/test/java/devkor/ontime_back/service/PreparationUserServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/PreparationUserServiceTest.java
@@ -1,0 +1,300 @@
+package devkor.ontime_back.service;
+
+import devkor.ontime_back.dto.PreparationDto;
+import devkor.ontime_back.entity.*;
+import devkor.ontime_back.repository.*;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class PreparationUserServiceTest {
+
+    @Autowired
+    private PreparationUserRepository preparationUserRepository;
+
+    @Autowired
+    private PreparationScheduleRepository preparationScheduleRepository;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PreparationUserService preparationUserService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @AfterEach
+    void tearDown() {
+        preparationUserRepository.deleteAll();
+        preparationScheduleRepository.deleteAll();
+        scheduleRepository.deleteAllInBatch();
+        placeRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("회원가입 시 기본 준비과정 설정 성공한다.")
+    void setFirstPreparationUser_success() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationUserService.setFirstPreparationUser(newUser.getId(), preparationDtoList);
+
+        // then
+        List<PreparationUser> savedPreparations = preparationUserRepository.findByUserIdWithNextPreparation(newUser.getId());
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationUser::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 회원가입 시 기본 준비과정 설정시 실패한다.")
+    void setFirstPreparationUser_userNotFound() {
+        // given
+        Long userId = 1L;
+
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        // when & then
+        assertThatThrownBy(() -> preparationUserService.setFirstPreparationUser(userId, preparationDtoList))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("사용자 ID " + userId + "에 해당하는 사용자를 찾을 수 없습니다.");
+
+    }
+
+    @Test
+    @DisplayName("준비과정 수정 성공한다.")
+    void updatePreparationUsers_success() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationUserService.updatePreparationUsers(newUser.getId(), preparationDtoList);
+
+        // then
+        List<PreparationUser> savedPreparations = preparationUserRepository.findByUserIdWithNextPreparation(newUser.getId());
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationUser::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 준비과정 수정시 실패한다.")
+    void updatePreparationUsers_userNotFound() {
+        // given
+        Long userId = 1L;
+
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        // when & then
+        assertThatThrownBy(() -> preparationUserService.updatePreparationUsers(userId, preparationDtoList))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("사용자 ID " + userId + "에 해당하는 사용자를 찾을 수 없습니다.");
+
+    }
+
+    @Test
+    @DisplayName("준비과정 조회를 성공한다.")
+    void showAllPreparationUsers_success() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+        UUID preparationUser3Id = UUID.randomUUID();
+
+        PreparationUser preparationUser3 = preparationUserRepository.save(new PreparationUser(
+                preparationUser3Id, newUser, "화장", 10, null));
+        PreparationUser preparationUser2= preparationUserRepository.save(new PreparationUser(
+                preparationUser2Id, newUser, "아침식사", 10, preparationUser3));
+        PreparationUser preparationUser1= preparationUserRepository.save(new PreparationUser(
+                preparationUser1Id, newUser, "세면", 10, preparationUser2));
+        preparationUserRepository.save(preparationUser1);
+        preparationUserRepository.save(preparationUser2);
+        preparationUserRepository.save(preparationUser3);
+
+        // when
+        List<PreparationDto> result = preparationUserService.showAllPreparationUsers(newUser.getId());
+
+        // then
+        assertNotNull(result);
+        assertEquals(3, result.size());
+
+        assertEquals(preparationUser1Id, result.get(0).getPreparationId());
+        assertEquals("세면", result.get(0).getPreparationName());
+        assertEquals(10, result.get(0).getPreparationTime());
+        assertEquals(preparationUser2Id, result.get(0).getNextPreparationId());
+
+        assertEquals(preparationUser2Id, result.get(1).getPreparationId());
+        assertEquals("아침식사", result.get(1).getPreparationName());
+        assertEquals(10, result.get(1).getPreparationTime());
+        assertEquals(preparationUser3Id, result.get(1).getNextPreparationId());
+
+        assertEquals(preparationUser3Id, result.get(2).getPreparationId());
+        assertEquals("화장", result.get(2).getPreparationName());
+        assertEquals(10, result.get(2).getPreparationTime());
+        assertNull(result.get(2).getNextPreparationId());
+    }
+
+    @Test
+    @DisplayName("준비과정이 없는 사용자가 준비과정 조회시 실패한다.")
+    void showAllPreparationUsers_notFound() {
+        // given
+        Long userId = 1L;
+
+        // when & then
+        assertThatThrownBy(() -> preparationUserService.showAllPreparationUsers(userId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("사용자 ID " + userId + "에 대한 시작 준비 단계를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("기존 데이터를 삭제하지 않고 준비과정 설정을 성공한다.")
+    void handlePreparationUsers_withoutDeletingExisting() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationUserService.handlePreparationUsers(newUser, preparationDtoList, false);
+
+        // then
+        List<PreparationUser> savedPreparations = preparationUserRepository.findByUserIdWithNextPreparation(newUser.getId());
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationUser::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+    }
+
+    @Test
+    @DisplayName("기존 데이터를 삭제하고 준비과정 설정을 성공한다.")
+    void handlePreparationUsers_withDeletingExisting() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        UUID preparationUser1Id = UUID.randomUUID();
+        UUID preparationUser2Id = UUID.randomUUID();
+
+        PreparationUser preparationUser3 = preparationUserRepository.save(new PreparationUser(
+                UUID.randomUUID(), newUser, "화장", 10, null));
+        PreparationUser preparationUser2= preparationUserRepository.save(new PreparationUser(
+                UUID.randomUUID(), newUser, "아침식사", 10, preparationUser3));
+        PreparationUser preparationUser1= preparationUserRepository.save(new PreparationUser(
+                UUID.randomUUID(), newUser, "알림확인", 10, preparationUser2));
+        preparationUserRepository.save(preparationUser1);
+        preparationUserRepository.save(preparationUser2);
+        preparationUserRepository.save(preparationUser3);
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationUser1Id, "세면", 10, preparationUser2Id),
+                new PreparationDto(preparationUser2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationUserService.handlePreparationUsers(newUser, preparationDtoList, true);
+
+        // then
+        List<PreparationUser> savedPreparations = preparationUserRepository.findByUserIdWithNextPreparation(newUser.getId());
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationUser::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+    }
+
+}


### PR DESCRIPTION
## 추가한 코드
- 리팩토링 과정에서 통일한 getUserIdFromToken를 모두 userAuthService에서 불러오도록 수정
- Controller 테스트 - API 응답을 검증하는 것이 목적 -> Mocking을 활용하여 ScheduleService의 의존성을 제거
- Service 테스트 - 실제 데이터 저장 및 조회가 필요한 로직 -> DB를 사용하여 검증
- Mockito.verify()를 활용하여 서비스 메서드가 기대한 횟수만큼 호출되었는지 검증
- PreparationUserControllerTest 파일 설정을 위해 ControllerTestSupport 설정 추가 

## PreparationUserServiceTest 결과
![image](https://github.com/user-attachments/assets/13346098-85d9-4c17-aca5-c0dafc2c84c5)

## PreparationUserControllerTest 결과
![image](https://github.com/user-attachments/assets/7da780c5-a8d2-4b9f-8d63-5df73060bf30)

close #102 
