### PR TITLE
[Feat&Mod] flyway 세팅 및 docker-compose 파일 수정

### DIFF
--- a/ontime-back/build.gradle
+++ b/ontime-back/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:9.2.0'
 
 	// flyway
-//	implementation 'org.flywaydb:flyway-mysql'
+	implementation 'org.flywaydb:flyway-mysql'
 
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 

--- a/ontime-back/docker-compose.yml
+++ b/ontime-back/docker-compose.yml
@@ -16,20 +16,3 @@ services:
 
     depends_on:
       - mysql # mysql 서비스가 실행된 이후에 backend를 실행
-
-  mysql:
-    image: mysql:8.0.34 # MySQL 8.0.34 이미지
-    container_name: mysql-container-ontime
-    environment:
-      MYSQL_DATABASE: ontime_db
-      MYSQL_USER: ontime
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      ONTIME_PASSWORD: ${ONTIME_PASSWORD}
-      ONTIME_HOST: ${ONTIME_HOST}
-    ports:
-      - "3307:3306" # 호스트의 3306 포트를 컨테이너의 3306 포트로 매핑
-    volumes:
-      - mysql_data:/var/lib/mysql # MySQL 데이터를 지속적으로 저장
-volumes:
-  mysql_data: # MySQL 데이터를 저장할 볼륨 정의

--- a/ontime-back/src/main/resources/db/migration/V1__init.sql
+++ b/ontime-back/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,100 @@
+CREATE TABLE api_log (
+                         api_log_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         request_url VARCHAR(255),
+                         request_method VARCHAR(10),
+                         user_id VARCHAR(255),
+                         client_ip VARCHAR(50),
+                         response_status INT,
+                         taken_time BIGINT,
+                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE user (
+                      user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                      email VARCHAR(255) UNIQUE NOT NULL,
+                      password VARCHAR(255),
+                      image_url VARCHAR(255),
+                      name VARCHAR(30),
+                      spare_time INT,
+                      note TEXT,
+                      punctuality_score FLOAT,
+                      schedule_count_after_reset INT,
+                      lateness_count_after_reset INT,
+                      role VARCHAR(20) NOT NULL,
+                      social_type VARCHAR(20),
+                      social_id VARCHAR(255) UNIQUE,
+                      refresh_token TEXT,
+                      firebase_token TEXT,
+                      social_login_token TEXT
+);
+
+CREATE TABLE place (
+                       place_id BINARY(36) PRIMARY KEY,
+                       place_name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE schedule (
+                          schedule_id BINARY(36) PRIMARY KEY,
+                          user_id BIGINT NOT NULL,
+                          place_id BINARY(36),
+                          schedule_name VARCHAR(30) NOT NULL,
+                          move_time INT,
+                          schedule_time TIMESTAMP,
+                          is_change TINYINT(1),
+                          is_started TINYINT(1),
+                          schedule_spare_time INT,
+                          lateness_time INT,
+                          schedule_note TEXT,
+                          CONSTRAINT fk_schedule_user FOREIGN KEY (user_id) REFERENCES user (user_id) ON DELETE CASCADE,
+                          CONSTRAINT fk_schedule_place FOREIGN KEY (place_id) REFERENCES place (place_id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_schedule_user_id ON schedule(user_id);
+CREATE INDEX idx_schedule_time ON schedule(schedule_time);
+
+CREATE TABLE feedback (
+                          feedback_id BINARY(36) PRIMARY KEY,
+                          message TEXT NOT NULL,
+                          create_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                          user_id BIGINT NOT NULL,
+                          CONSTRAINT fk_feedback_user FOREIGN KEY (user_id) REFERENCES user (user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE friend_ship (
+                            friend_ship_id BINARY(36) PRIMARY KEY,
+                            requester_id BIGINT NOT NULL,
+                            receiver_id BIGINT,
+                            accept_status VARCHAR(20) NOT NULL,
+                            CONSTRAINT fk_friendship_requester FOREIGN KEY (requester_id) REFERENCES user (user_id) ON DELETE CASCADE,
+                            CONSTRAINT fk_friendship_receiver FOREIGN KEY (receiver_id) REFERENCES user (user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE preparation_schedule (
+                                      preparation_schedule_id BINARY(36) PRIMARY KEY,
+                                      schedule_id BINARY(36) NOT NULL,
+                                      preparation_name VARCHAR(30) NOT NULL,
+                                      preparation_time INT,
+                                      next_preparation_id BINARY(36),
+                                      CONSTRAINT fk_preparation_schedule FOREIGN KEY (schedule_id) REFERENCES schedule (schedule_id) ON DELETE CASCADE,
+                                      CONSTRAINT fk_next_preparation FOREIGN KEY (next_preparation_id) REFERENCES preparation_schedule (preparation_schedule_id)
+);
+
+CREATE TABLE preparation_user (
+                                  preparation_id BINARY(36) PRIMARY KEY,
+                                  user_id BIGINT NOT NULL,
+                                  preparation_name VARCHAR(30) NOT NULL,
+                                  preparation_time INT,
+                                  next_preparation_id BINARY(36),
+                                  CONSTRAINT fk_preparation_user FOREIGN KEY (user_id) REFERENCES user (user_id) ON DELETE CASCADE,
+                                  CONSTRAINT fk_next_preparation_user FOREIGN KEY (next_preparation_id) REFERENCES preparation_user (preparation_id)
+);
+
+CREATE TABLE user_setting (
+                              user_setting_id BINARY(36) PRIMARY KEY,
+                              user_id BIGINT NOT NULL,
+                              is_notifications_enabled TINYINT(1) DEFAULT 1,
+                              sound_volume INT DEFAULT 50,
+                              is_play_on_speaker TINYINT(1) DEFAULT 1,
+                              is24hour_format TINYINT(1) DEFAULT 1,
+                              CONSTRAINT fk_user_setting FOREIGN KEY (user_id) REFERENCES user (user_id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## 추가한 코드
- `build.gradle` - `implementation 'org.flywaydb:flyway-mysql'` 추가
- `V1__init.sql` - 기존에 JPA를 사용하여 엔티티가 자동으로 데이터베이스에 생성되었던 부분을 SQL 스크립트를 직접 작성하여 테이블을 생성
- `docker-compose.yml` - mysql-container와의 연결 부분 삭제

## flyway 

### db 마이그레이션 툴 사용 계기
- 데이터베이스 변경을 체계적으로 관리하고, 안정성을 유지하면서 운영 환경에 반영

### flyway 채택 이유
- 스프링부트가 지원하는 마이그레이션 툴 : (대표적) flyway + liquibase
- 주로 SQL을 사용할 것 같아, JSON, YAML 등을 제공하는 추상화를 누릴 수 있는 Liquibase가 매력적이지 않음
- Flyway가 공식 문서가 좀 더 상세히 작성 + 레퍼런스가 더 많음

### flyway 역할
- 데이터베이스 버전 관리
- 자동 마이그레이션 수행
- 여러 환경(로컬, 개발, 운영)에서 동일한 스키마 유지

### flyway 동작 방식
1. flyway_schema_history 테이블 생성 - 마이그레이션 이력 저장
2. SQL 마이그레이션 파일 실행 
3. 실행된 마이그레이션은 flyway_schema_history에 기록
4. 새로운 SQL 스크립트가 추가되면 이전 기록과 비교하여 적용되지 않은 것만 실행
(마이그레이션 파일은 DB 변경이 필요할 때마다 개발자가 직접 SQL 파일을 작성)

간단히 요약하자면, sql 마이그레이션 파일로 db를 **형상 관리**하고 `spring.jpa.hibernate.ddl-auto=validate` 옵션을 활용한 **검증**을 하도록 설정하였습니다.