### PR TITLE
[Mod] preparationSchedule api 테스트코드 작성

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationScheduleController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/PreparationScheduleController.java
@@ -70,7 +70,7 @@ public class PreparationScheduleController {
             @ApiResponse(responseCode = "4XX", description = "잘못된 요청", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
     })
     @PostMapping("/modify/{scheduleId}")
-    public ResponseEntity<ApiResponseForm<Void>> modifyPreparationUser(HttpServletRequest request, @Parameter(description = "스케줄 ID (UUID 형식)", required = true, example = "3fa85f64-5717-4562-b3fc-2c963f66afe5") @PathVariable UUID scheduleId, @RequestBody List<PreparationDto> preparationDtoList) {
+    public ResponseEntity<ApiResponseForm<Void>> modifyPreparationSchedule(HttpServletRequest request, @Parameter(description = "스케줄 ID (UUID 형식)", required = true, example = "3fa85f64-5717-4562-b3fc-2c963f66afe5") @PathVariable UUID scheduleId, @RequestBody List<PreparationDto> preparationDtoList) {
         Long userId = userAuthService.getUserIdFromToken(request);
 
         preparationScheduleService.updatePreparationSchedules(userId, scheduleId, preparationDtoList);

--- a/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/ControllerTestSupport.java
@@ -17,7 +17,8 @@ import org.springframework.test.web.servlet.MockMvc;
                 UserController.class,
                 ScheduleController.class,
                 FriendShipController.class,
-                PreparationUserController.class
+                PreparationUserController.class,
+                PreparationScheduleController.class
         }
 )
 public abstract class ControllerTestSupport {
@@ -42,6 +43,9 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected PreparationUserService preparationUserService;
+
+    @MockBean
+    protected PreparationScheduleService preparationScheduleService;
 
     @MockBean
     protected UserRepository userRepository;

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/PreparationScheduleControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/PreparationScheduleControllerTest.java
@@ -1,0 +1,88 @@
+package devkor.ontime_back.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devkor.ontime_back.ControllerTestSupport;
+import devkor.ontime_back.TestSecurityConfig;
+import devkor.ontime_back.dto.PreparationDto;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestSecurityConfig.class)
+public class PreparationScheduleControllerTest extends ControllerTestSupport {
+
+    @Test
+    @DisplayName("스케줄별 준비과정 생성에 성공한다.")
+    void createPreparationSchedule_success() throws Exception {
+        // given
+        UUID scheduleId = UUID.randomUUID();
+        Long userId = 1L;
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(UUID.randomUUID(), "세면", 10, UUID.randomUUID()),
+                new PreparationDto(UUID.randomUUID(), "옷입기", 15, null)
+        );
+
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        doNothing().when(preparationScheduleService).makePreparationSchedules(eq(userId), eq(scheduleId), any());
+
+        // when & then
+        mockMvc.perform(post("/preparationschedule/create/{scheduleId}", scheduleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(preparationDtoList))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("OK"));
+
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(preparationScheduleService, times(1))
+                .makePreparationSchedules(eq(userId), eq(scheduleId), argThat(list -> list.size() == preparationDtoList.size()));
+    }
+
+    @Test
+    @DisplayName("스케줄별 준비과정 수정에 성공한다.")
+    void modifyPreparationSchedule_success() throws Exception {
+        // given
+        UUID scheduleId = UUID.randomUUID();
+        Long userId = 1L;
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(UUID.randomUUID(), "세면", 10, UUID.randomUUID()),
+                new PreparationDto(UUID.randomUUID(), "옷입기", 15, null)
+        );
+
+        when(userAuthService.getUserIdFromToken(any(HttpServletRequest.class))).thenReturn(userId);
+        doNothing().when(preparationScheduleService).updatePreparationSchedules(eq(userId), eq(scheduleId), any());
+
+        // when & then
+        mockMvc.perform(post("/preparationschedule/modify/{scheduleId}", scheduleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(preparationDtoList))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.message").value("OK"));
+
+        verify(userAuthService, times(1)).getUserIdFromToken(any(HttpServletRequest.class));
+        verify(preparationScheduleService, times(1))
+                .updatePreparationSchedules(eq(userId), eq(scheduleId), argThat(list -> list.size() == preparationDtoList.size()));
+    }
+
+}

--- a/ontime-back/src/test/java/devkor/ontime_back/service/PreparationScheduleServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/PreparationScheduleServiceTest.java
@@ -1,0 +1,344 @@
+package devkor.ontime_back.service;
+
+import devkor.ontime_back.dto.PreparationDto;
+import devkor.ontime_back.entity.*;
+import devkor.ontime_back.repository.*;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+public class PreparationScheduleServiceTest {
+
+    @Autowired
+    private PreparationUserRepository preparationUserRepository;
+
+    @Autowired
+    private PreparationScheduleRepository preparationScheduleRepository;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PreparationScheduleService preparationScheduleService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @AfterEach
+    void tearDown() {
+        preparationUserRepository.deleteAll();
+        preparationScheduleRepository.deleteAll();
+        scheduleRepository.deleteAllInBatch();
+        placeRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("새로운 데이터로 준비과정 설정을 성공한다.")
+    void makePreparationSchedules_withoutDeletingExisting() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        Place place1 = Place.builder()
+                .placeId(UUID.fromString("70d460da-6a82-4c57-a285-567cdeda5601"))
+                .placeName("과학도서관")
+                .build();
+        placeRepository.save(place1);
+
+        Schedule addedSchedule1 = Schedule.builder()
+                .scheduleId(UUID.fromString("023e4567-e89b-12d3-a456-426614170001"))
+                .scheduleName("공부하기")
+                .scheduleTime(LocalDateTime.of(2025, 2, 23, 7, 0))
+                .moveTime(10)
+                .latenessTime(-1)
+                .place(place1)
+                .user(newUser)
+                .build();
+        scheduleRepository.save(addedSchedule1);
+
+        UUID preparationSchedule1Id = UUID.randomUUID();
+        UUID preparationSchedule2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationSchedule1Id, "세면", 10, preparationSchedule2Id),
+                new PreparationDto(preparationSchedule2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationScheduleService.makePreparationSchedules(newUser.getId(), addedSchedule1.getScheduleId(), preparationDtoList);
+
+        // then
+        List<PreparationSchedule> savedPreparations = preparationScheduleRepository.findByScheduleWithNextPreparation(addedSchedule1);
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationSchedule::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+    }
+
+    @Test
+    @DisplayName("기존 준비 과정을 삭제한 후 새로운 준비과정 설정을 성공한다.")
+    void updatePreparationSchedules_withDeletingExisting() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        Place place1 = Place.builder()
+                .placeId(UUID.fromString("70d460da-6a82-4c57-a285-567cdeda5601"))
+                .placeName("과학도서관")
+                .build();
+        placeRepository.save(place1);
+
+        Schedule addedSchedule1 = Schedule.builder()
+                .scheduleId(UUID.fromString("023e4567-e89b-12d3-a456-426614170001"))
+                .scheduleName("공부하기")
+                .scheduleTime(LocalDateTime.of(2025, 2, 23, 7, 0))
+                .moveTime(10)
+                .latenessTime(-1)
+                .place(place1)
+                .user(newUser)
+                .build();
+        scheduleRepository.save(addedSchedule1);
+
+        PreparationSchedule preparationSchedule3 = preparationScheduleRepository.save(new PreparationSchedule(
+                UUID.randomUUID(), addedSchedule1, "화장", 10, null));
+        PreparationSchedule preparationSchedule2= preparationScheduleRepository.save(new PreparationSchedule(
+                UUID.randomUUID(), addedSchedule1, "아침식사", 10, preparationSchedule3));
+        PreparationSchedule preparationSchedule1= preparationScheduleRepository.save(new PreparationSchedule(
+                UUID.randomUUID(), addedSchedule1, "알림확인", 10, preparationSchedule2));
+
+        UUID preparationSchedule1Id = UUID.randomUUID();
+        UUID preparationSchedule2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationSchedule1Id, "세면", 10, preparationSchedule2Id),
+                new PreparationDto(preparationSchedule2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationScheduleService.updatePreparationSchedules(newUser.getId(), addedSchedule1.getScheduleId(), preparationDtoList);
+
+        // then
+        List<PreparationSchedule> savedPreparations = preparationScheduleRepository.findByScheduleWithNextPreparation(addedSchedule1);
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationSchedule::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+    }
+
+    @Test
+    @DisplayName("기존 데이터를 삭제하지 않고 준비과정 설정을 성공한다.")
+    void handlePreparationSchedules_withoutDeletingExisting() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        Place place1 = Place.builder()
+                .placeId(UUID.fromString("70d460da-6a82-4c57-a285-567cdeda5601"))
+                .placeName("과학도서관")
+                .build();
+        placeRepository.save(place1);
+
+        Schedule addedSchedule1 = Schedule.builder()
+                .scheduleId(UUID.fromString("023e4567-e89b-12d3-a456-426614170001"))
+                .scheduleName("공부하기")
+                .scheduleTime(LocalDateTime.of(2025, 2, 23, 7, 0))
+                .moveTime(10)
+                .latenessTime(-1)
+                .place(place1)
+                .user(newUser)
+                .build();
+        scheduleRepository.save(addedSchedule1);
+
+        UUID preparationSchedule1Id = UUID.randomUUID();
+        UUID preparationSchedule2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationSchedule1Id, "세면", 10, preparationSchedule2Id),
+                new PreparationDto(preparationSchedule2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationScheduleService.handlePreparationSchedules(newUser.getId(), addedSchedule1.getScheduleId(), preparationDtoList, false);
+
+        // then
+        List<PreparationSchedule> savedPreparations = preparationScheduleRepository.findByScheduleWithNextPreparation(addedSchedule1);
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationSchedule::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+    }
+
+    @Test
+    @DisplayName("기존 데이터를 삭제한 후 준비과정 설정을 성공한다.")
+    void handlePreparationSchedules_withDeletingExisting() {
+        // given
+        User newUser = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser);
+
+        Place place1 = Place.builder()
+                .placeId(UUID.fromString("70d460da-6a82-4c57-a285-567cdeda5601"))
+                .placeName("과학도서관")
+                .build();
+        placeRepository.save(place1);
+
+        Schedule addedSchedule1 = Schedule.builder()
+                .scheduleId(UUID.fromString("023e4567-e89b-12d3-a456-426614170001"))
+                .scheduleName("공부하기")
+                .scheduleTime(LocalDateTime.of(2025, 2, 23, 7, 0))
+                .moveTime(10)
+                .latenessTime(-1)
+                .place(place1)
+                .user(newUser)
+                .build();
+        scheduleRepository.save(addedSchedule1);
+
+        PreparationSchedule preparationSchedule3 = preparationScheduleRepository.save(new PreparationSchedule(
+                UUID.randomUUID(), addedSchedule1, "화장", 10, null));
+        PreparationSchedule preparationSchedule2= preparationScheduleRepository.save(new PreparationSchedule(
+                UUID.randomUUID(), addedSchedule1, "아침식사", 10, preparationSchedule3));
+        PreparationSchedule preparationSchedule1= preparationScheduleRepository.save(new PreparationSchedule(
+                UUID.randomUUID(), addedSchedule1, "알림확인", 10, preparationSchedule2));
+
+        UUID newPreparationSchedule1Id = UUID.randomUUID();
+        UUID newPreparationSchedule2Id = UUID.randomUUID();
+
+        List<PreparationDto> newPreparationDtoList = List.of(
+                new PreparationDto(newPreparationSchedule1Id, "세면", 10, newPreparationSchedule2Id),
+                new PreparationDto(newPreparationSchedule2Id, "옷입기", 15, null)
+        );
+
+        // when
+        preparationScheduleService.handlePreparationSchedules(newUser.getId(), addedSchedule1.getScheduleId(), newPreparationDtoList, true);
+
+        // then
+        List<PreparationSchedule> savedPreparations = preparationScheduleRepository.findByScheduleWithNextPreparation(addedSchedule1);
+
+        assertThat(savedPreparations).hasSize(2);
+        assertThat(savedPreparations).extracting(PreparationSchedule::getPreparationName)
+                .containsExactlyInAnyOrder("세면", "옷입기");
+
+        assertThat(savedPreparations).extracting(PreparationSchedule::getPreparationName)
+                .doesNotContain("알림확인", "아침식사", "화장");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 일정 ID로 요청 시 준비과정 설정을 실패한다.")
+    void handlePreparationSchedules_withInvalidScheduleId() {
+        // given
+        Long userId = 1L;
+        UUID invalidScheduleId = UUID.randomUUID();
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(UUID.randomUUID(), "세면", 10, null)
+        );
+
+        // when & then
+        assertThatThrownBy(() ->
+                preparationScheduleService.handlePreparationSchedules(userId, invalidScheduleId, preparationDtoList, false))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("해당 ID의 일정을 찾을 수 없습니다: " + invalidScheduleId);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 준비과정 설정시 실패한다.")
+    void handlePreparationSchedules_withUnauthorizedUser() {
+        // given
+        User newUser1 = User.builder()
+                .email("user@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("jinsuh")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser1);
+
+        User newUser2 = User.builder()
+                .email("user1@example.com")
+                .password(passwordEncoder.encode("password1234"))
+                .name("suhjin")
+                .punctualityScore(-1f)
+                .scheduleCountAfterReset(0)
+                .latenessCountAfterReset(0)
+                .build();
+        userRepository.save(newUser2);
+
+        Place place1 = Place.builder()
+                .placeId(UUID.fromString("70d460da-6a82-4c57-a285-567cdeda5601"))
+                .placeName("과학도서관")
+                .build();
+        placeRepository.save(place1);
+
+        Schedule addedSchedule1 = Schedule.builder()
+                .scheduleId(UUID.fromString("023e4567-e89b-12d3-a456-426614170001"))
+                .scheduleName("공부하기")
+                .scheduleTime(LocalDateTime.of(2025, 2, 23, 7, 0))
+                .moveTime(10)
+                .latenessTime(-1)
+                .place(place1)
+                .user(newUser1)
+                .build();
+        scheduleRepository.save(addedSchedule1);
+
+        UUID preparationSchedule1Id = UUID.randomUUID();
+        UUID preparationSchedule2Id = UUID.randomUUID();
+
+        List<PreparationDto> preparationDtoList = List.of(
+                new PreparationDto(preparationSchedule1Id, "세면", 10, preparationSchedule2Id),
+                new PreparationDto(preparationSchedule2Id, "옷입기", 15, null)
+        );
+
+        // when & then
+        assertThatThrownBy(() ->
+                preparationScheduleService.handlePreparationSchedules(newUser2.getId(), addedSchedule1.getScheduleId(), preparationDtoList, false))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("사용자가 해당 일정에 대한 권한이 없습니다");
+    }
+
+
+}
+


### PR DESCRIPTION
## 추가한 코드
- Controller 테스트 - API 응답을 검증
- Service 테스트 - 실제 데이터 저장 및 조회를 DB를 사용하여 검증
- PreparationScheduleControllerTest 파일 설정을 위해 ControllerTestSupport 설정 추가
- PreparationScheduleController에 있는 modifyPreparationSchedule 메서드명 수정

## PreparationScheduleServiceTest 결과
![image](https://github.com/user-attachments/assets/78cd2b08-3418-4d51-a272-6814d14d837b)

## PreparationScheduleControllerTest 결과
![image](https://github.com/user-attachments/assets/a26c4eb2-538e-40db-b323-ce267b59e624)
