### PR TITLE
[Mod] 토큰 관련 응답 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
@@ -57,21 +57,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // accesstoken valid
             if (jwtTokenProvider.isTokenValid(accessToken)) {
-                log.info("1");
                 checkAccessTokenAndAuthentication(request, response, filterChain);
                 return;
             }
             // accesstoken not valid
             if (accessToken != null && !jwtTokenProvider.isTokenValid(accessToken)) {
-                log.info("2");
-                checkRefreshTokenAndReIssueAccessToken(request, response, refreshToken, filterChain);
                 sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "ACCESS_TOKEN_EXPIRED", "AccessToken이 만료되었습니다.");
                 return;
             }
 
             // refreshtoken valid
-            if (jwtTokenProvider.isTokenValid(refreshToken)) {
-                log.info("3");
+            if (refreshToken != null && jwtTokenProvider.isTokenValid(refreshToken)) {
                 checkRefreshTokenAndReIssueAccessToken(request, response, refreshToken, filterChain);
                 sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "ACCESS_TOKEN_ISSUED", "새로운 AccessToken이 발급되었습니다.");
                 return;
@@ -79,14 +75,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // refreshtoken not valid
             if (refreshToken != null && !jwtTokenProvider.isTokenValid(refreshToken)) {
-                log.info("4");
                 sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "REFRESH_TOKEN_EXPIRED", "RefreshToken이 만료되었습니다. 다시 로그인하세요.");
                 return;
             }
 
             // accesstoken, refreshtoken empty
             if(accessToken == null && refreshToken == null) {
-                log.info("5");
                 sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "AUTHENTICATION_FAILED", "AccessToken와 RefreshToken가 유효하지 않습니다.");
                 return;
             }

--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
@@ -1,3 +1,5 @@
+
+
 package devkor.ontime_back.global.jwt;
 
 import com.auth0.jwt.JWT;
@@ -158,7 +160,7 @@ public class JwtTokenProvider {
             return true;
         } catch (Exception e) {
             log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
-            throw new InvalidTokenException("유효하지 않은 토큰입니다.");
+            return false;
         }
     }
 


### PR DESCRIPTION
## 수정한 코드
- isTokenValid - 유효하지 않은 토큰이 들어왔을때 false로 처리하여 jwtauthenticationfilter 조건문에서 사용
- accesstoken, refreshtoken 조건에 따른 응답 수정
- sendErrorResponse - 응답 보내는 메서드 추가

## 응답 메시지 형식
v: valid, nv: not valid, x: 없음(빈칸)
**1. accesstoken valid - 유효한 accesstoken**
- accesstoken v refreshtoken v - api 실행
- accesstoken v refreshtoken nv, x - accesstoken으로 api 실행

-> 정상적인 메서드 응답 

**2. accesstoken x or not valid, refreshtoken valid - refreshtoken만 유효**
refreshtoken으로 accesstoken 재발급
- accesstoken nv refreshtoken v - accesstoken 만료 -> accesstoken 재발급
```
{
    "status": "error",
    "code": "ACCESS_TOKEN_EXPIRED",
    "message": "AccessToken이 만료되었습니다.",
    "data": null
}
```
- accesstoken x refrestoken v - (accesstoken 빈칸이지만) refreshtoken으로 -> accesstoken 재발급
```
{
    "status": "error",
    "code": "ACCESS_TOKEN_REQUIRED",
    "message": "AccessToken이 필요합니다.",
    "data": null
}
```
**3. accesstoken not valid, refreshtoken not valid - accesstoken, refreshtoken 모두 만료**
- accesstoken nv refreshtoken nv - refreshtoken 만료 (로그아웃 필요)
```
{
    "status": "error",
    "code": "REFRESH_TOKEN_EXPIRED",
    "message": "RefreshToken이 만료되었습니다. 다시 로그인하세요.",
    "data": null
}
```
**4. others**
accesstoken nv refreshtoken x - (인증 불가능)
accesstoken x refreshtoken nv - (인증 불가능)
accesstoken x refreshtoken x - (인증 불가능)
```
{
    "status": "error",
    "code": "AUTHENTICATION_FAILED",
    "message": "AccessToken과 RefreshToken이 유효하지 않습니다. 다시 로그인하세요.",
    "data": null
}
```
