### PR TITLE
[Mod] NO_CHECK_URLS 추가

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.IOException;
 import java.security.SecureRandom;
+import java.util.List;
 
 import jakarta.servlet.ServletException;
 
@@ -32,7 +33,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private static final String NO_CHECK_URL = "/login"; // "/login"으로 들어오는 요청은 Filter 작동 X
+    private static final List<String> NO_CHECK_URLS = List.of("/login", "/swagger-ui", "/sign-up", "/v3/api-docs"); // "/login"으로 들어오는 요청은 Filter 작동 X
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
@@ -41,17 +42,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
         try {
-            if (request.getRequestURI().equals(NO_CHECK_URL)) {
+            if (NO_CHECK_URLS.stream().anyMatch(requestURI::startsWith)) {
                 filterChain.doFilter(request, response);
                 return;
             }
 
             String accessToken= jwtTokenProvider.extractAccessToken(request)
                     .orElse(null);
+            log.info("accesstoken: {}", accessToken);
 
             String refreshToken = jwtTokenProvider.extractRefreshToken(request)
                     .orElse(null);
+            log.info("refreshtoken: {}", refreshToken);
 
             if (refreshToken != null) {
                 checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
@@ -67,6 +71,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 response.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid Access token.");
                 return;
             }
+
 
         }
         catch (InvalidTokenException ex) {

--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
@@ -51,11 +51,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             String accessToken= jwtTokenProvider.extractAccessToken(request)
                     .orElse(null);
-            log.info("accesstoken: {}", accessToken);
 
             String refreshToken = jwtTokenProvider.extractRefreshToken(request)
                     .orElse(null);
-            log.info("refreshtoken: {}", refreshToken);
 
             if (refreshToken != null) {
                 checkRefreshTokenAndReIssueAccessToken(response, refreshToken);


### PR DESCRIPTION
## 추가한 코드
- NO_CHECK_URLS에 /swagger관련 주소와 /sign-up 추가

## 해결 과정

### 문제 
swagger와 sign-up 접근이 안됨

### 원인
.permitAll() 설정은 Security 인증을 허용하지만, JwtAuthenticationFilter는 그대로 실행됨. JwtAuthenticationFilter에서 accessToken == null && refreshToken == null이면 요청이 컨트롤러까지 가지 않고 필터 체인에서 종료됨.
	(Security에서 허용하더라도 JwtAuthenticationFilter가 먼저 실행되면 요청이 거부될 수 있음.)


### 기존 코드에서 됐던 이유
기존 코드에서는 accesstoken, refreshtoken 둘다 없을때 if (refreshToken == null) 를 통과하면서 checkAccessTokenAndAuthentication()가 실행되면서 JWT 없이도 filterChain.doFilter()가 호출되어 요청이 컨트롤러까지 도달했음.

### 해결 방법
NO_CHECK_URLS에 /swagger관련 주소와 /sign-up 추가하여 JwtAuthenticationFilter를 통과하지 않도록 설정

### 중요한점
- .permitAll() 설정은 Security 인증을 허용하지만, JwtAuthenticationFilter는 그대로 실행됨. Security 인증은 컨트롤러에서 적용됨 
- Security의 인증 흐름
  - Http 요청 → JwtAuthenticationFilter가 실행됨.
  - (NO_CHECK_URLS에 포함된 경우, 필터를 건너뛰고 Security까지 요청이 전달됨.)
  - Security에서 .permitAll()이 적용되면 인증 없이 접근 가능.
  - .authenticated()가 적용된 경우, SecurityContextHolder를 확인하여 인증이 필요함.