### PR TITLE
[Mod] setExposedHeaders 설정 추가

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/config/SecurityConfig.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/SecurityConfig.java
@@ -37,6 +37,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+
 /**
  * 인증은 CustomJsonUsernamePasswordAuthenticationFilter에서 authenticate()로 인증된 사용자로 처리
  * JwtAuthenticationProcessingFilter는 AccessToken, RefreshToken 재발급
@@ -138,6 +140,7 @@ public class SecurityConfig {
         configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
         configuration.addAllowedHeader("*"); // 모든 헤더 허용
         configuration.setAllowCredentials(true); // 쿠키 포함 허용
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Authorization-refresh"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;


### PR DESCRIPTION
## 추가한 코드
- Authorization, Authorization-refresh 헤더 관련해서 setExposedHeaders 설정 추가

## 해결 내용
**문제) Authorization 헤더를 클라이언트에서 받을 수 없음**
- 브라우저의 보안 정책으로 인해 Authorization, Set-Cookie, WWW-Authenticate 같은 민감한 헤더는 기본적으로 숨겨짐

**해결방법) setExposedHeaders를 사용**
- 클라이언트(프론트엔드)에서 Authorization, Authorization-refresh 헤더에 접근할 수 있도록 허용


## 결과
변경 전
![image](https://github.com/user-attachments/assets/7c6ab49b-b87d-448a-a87d-cb9a179909f7)

변경 후
![image](https://github.com/user-attachments/assets/30f7dae5-8746-401b-b67f-e606dd52814d)

요청 자체는 인증이 없어서 401 Unauthorized로 거부되었지만 CORS 헤더는 응답에 포함되어서 CORS 설정이 적용되고 있음을 확인가능합니다. 변경 후에는 Access-Control-Expose-Headers 포함되어 클라이언트가 접근 가능함을 확인할 수 있습니다.
