### PR TITLE
[Hotfix] 알림스케줄러에서 User의 firebase 토큰을 사용하려고 할 때 지연로딩되지 않는 현상 해결 

### DIFF
--- a/ontime-back/.gitignore
+++ b/ontime-back/.gitignore
@@ -23,6 +23,8 @@ bin/
 
 ### IntelliJ IDEA ###
 .idea
+../.idea
+../.DS_Store
 *.iws
 *.iml
 *.ipr

--- a/ontime-back/src/main/java/devkor/ontime_back/config/FirebaseInitialization.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/FirebaseInitialization.java
@@ -12,22 +12,14 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
-@Slf4j
 @Service
 public class FirebaseInitialization {
 
     @PostConstruct
     public void initialize() {
         try {
-            if (!FirebaseApp.getApps().isEmpty()) {
-                log.info("firebaseApp is already exist 이미 있어 파베가. 이미 등록했어");
-            }
-//            FileInputStream serviceAccount =
-//                    new FileInputStream("src/main/resources/ontime-c63f1-firebase-adminsdk-fbsvc-a043cdc829.json");
-
             InputStream serviceAccount = getClass().getClassLoader().getResourceAsStream("ontime-c63f1-firebase-adminsdk-fbsvc-a043cdc829.json");
             if (serviceAccount == null) {
-                log.error("json파일을 찾지 못했어요 ㅠㅠ damn 차라리 이거면 좋겠다. it should be");
                 throw new FileNotFoundException("Resource not found: ontime-c63f1-firebase-adminsdk-fbsvc-a043cdc829.json");
             }
 
@@ -36,9 +28,7 @@ public class FirebaseInitialization {
                     .build();
 
             FirebaseApp.initializeApp(options);
-            log.info("Firebase 초기화에 성공했습니다 하하하하 이러면 디버깅이 괴장히 어려워짐!");
         } catch (IOException e) {
-            log.error("❌ Firebase 초기화 실패: " + e.getMessage(), e);
             e.printStackTrace();
         }
     }

--- a/ontime-back/src/main/java/devkor/ontime_back/config/FirebaseInitialization.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/FirebaseInitialization.java
@@ -3,6 +3,7 @@ package devkor.ontime_back.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -11,17 +12,22 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
+@Slf4j
 @Service
 public class FirebaseInitialization {
 
     @PostConstruct
     public void initialize() {
         try {
+            if (!FirebaseApp.getApps().isEmpty()) {
+                log.info("firebaseApp is already exist 이미 있어 파베가. 이미 등록했어");
+            }
 //            FileInputStream serviceAccount =
-//                    new FileInputStream("C:/Users/junbeom/Desktop/24-2/Devkor/Ontime/ontime-back/src/main/resources/ontime-push-firebase-adminsdk-gnpxs-7d098872ff.json");
+//                    new FileInputStream("src/main/resources/ontime-c63f1-firebase-adminsdk-fbsvc-a043cdc829.json");
 
             InputStream serviceAccount = getClass().getClassLoader().getResourceAsStream("ontime-c63f1-firebase-adminsdk-fbsvc-a043cdc829.json");
             if (serviceAccount == null) {
+                log.error("json파일을 찾지 못했어요 ㅠㅠ damn 차라리 이거면 좋겠다. it should be");
                 throw new FileNotFoundException("Resource not found: ontime-c63f1-firebase-adminsdk-fbsvc-a043cdc829.json");
             }
 
@@ -30,7 +36,9 @@ public class FirebaseInitialization {
                     .build();
 
             FirebaseApp.initializeApp(options);
+            log.info("Firebase 초기화에 성공했습니다 하하하하 이러면 디버깅이 괴장히 어려워짐!");
         } catch (IOException e) {
+            log.error("❌ Firebase 초기화 실패: " + e.getMessage(), e);
             e.printStackTrace();
         }
     }

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/ScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/ScheduleRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -42,8 +43,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, UUID> {
     List<Schedule> findSchedulesBetween(LocalDateTime start, LocalDateTime end);
 
     // 특정 시간에 시작하는 약속 조회 (예: 5분 후 약속)
-    @Query("SELECT s FROM Schedule s WHERE FUNCTION('HOUR', s.scheduleTime) = :hour AND FUNCTION('MINUTE', s.scheduleTime) = :minute")
-    List<Schedule> findSchedulesStartingAt(int hour, int minute);
+    @Query("SELECT s FROM Schedule s WHERE s.scheduleTime BETWEEN :startTime AND :endTime")
+    List<Schedule> findSchedulesStartingAt(@Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+
 
     // 지각 히스토리 조회(페치조인을 했었는데 본 메서드를 사용하는 서비스메서드에서 user를 참조하지 않아서 필요없음)
     @Query("SELECT s FROM Schedule s WHERE s.user.id = :userId AND s.latenessTime > 0")

--- a/ontime-back/src/main/java/devkor/ontime_back/scheduler/NotificationScheduler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/scheduler/NotificationScheduler.java
@@ -51,9 +51,13 @@ public class NotificationScheduler {
         LocalDateTime fiveMinutesLater = LocalDateTime.now().plusMinutes(5);
         int targetHour = fiveMinutesLater.getHour();
         int targetMinute = fiveMinutesLater.getMinute();
+        System.out.println("time now is:: " + targetHour + ":" + targetMinute);
 
         // 5분 후의 시각에 시작하는 약속 조회
         List<Schedule> schedulesStartingSoon = scheduleRepository.findSchedulesStartingAt(targetHour, targetMinute);
+        for(Schedule schedule : schedulesStartingSoon) {
+            System.out.println("5분뒤의 약속: " + schedule.getScheduleName());
+        }
 
         // 알림 전송
         notificationService.sendReminder(schedulesStartingSoon, "약속 5분 전입니다. 준비하세요.");

--- a/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
@@ -41,17 +41,15 @@ public class NotificationService {
         User user = schedule.getUser();
         String firebaseToken = user.getFirebaseToken();
 
-        System.out.println(user.getName() + "님 " + message + "\n약속: " + schedule); // 테스트용. 파이어베이스 확인되면 이 라인삭제해야함
-
         Message firebaseMessage = Message.builder()
                 .putData("title", "약속 알림")
-                .putData("content", user.getName() + "님 " + message + "\n약속: " + schedule)
+                .putData("content", user.getName() + "님 " + message + "\n약속명: " + schedule.getScheduleName())
                 .setToken(firebaseToken)
                 .build();
 
         try {
             String response = FirebaseMessaging.getInstance().send(firebaseMessage);
-            System.out.println("Successfully sent message: " + response);
+            System.out.println("Firebase에 성공적으로 push notification 요청을 보냈으며, Firebase로부터 적절한 응답을 받았습니다 \n응답 내용:" + response);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/UserAuthService.java
@@ -7,8 +7,6 @@ import devkor.ontime_back.entity.Role;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.entity.UserSetting;
 import devkor.ontime_back.global.jwt.JwtTokenProvider;
-import devkor.ontime_back.repository.PreparationScheduleRepository;
-import devkor.ontime_back.repository.PreparationUserRepository;
 import devkor.ontime_back.repository.UserRepository;
 import devkor.ontime_back.repository.UserSettingRepository;
 import devkor.ontime_back.response.ErrorCode;
@@ -31,10 +29,8 @@ public class UserAuthService {
 
     private final UserRepository userRepository;
     private final UserSettingRepository userSettingRepository;
-    private final PreparationUserRepository preparationUserRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final PreparationScheduleRepository preparationScheduleRepository;
 
     // 엑세스토큰에서 UserId 추출
     public Long getUserIdFromToken(HttpServletRequest request) {


### PR DESCRIPTION
## 수정한 코드
알림 스케줄러에 `@Transactional(readOnly = True)`를 걸어주었음.

## 발생했던 문제
`Schedule`에서 `getUser`로 가져온 `User`(프록시 객체)의 `firebaseToken`을 사용(`getFirebaseToken`)하려는 순간 지연로딩 에러가 발생함.

## 문제 원인
`@Scheduled` 애너테이션이 별도의 스레드에서 실행되고 트랜잭션이 없어 영속성 컨텍스트가 없어 `Schedule`에서 `User`를 지연로딩할 수 없었음.(프록시 객체로만 존재)

## 문제 해결
알림 스케줄러 전체에 `@Transactional(readOnly = True)`를 걸어 `@Scheduled`가 포함된 메서드들이 트랜잭션이 적용되게 하여 영속성 컨텍스트가 생성되게 해 문제 해결하였음.