### PR TITLE
[Mod] Error log 처리 방식 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
@@ -2,6 +2,7 @@ package devkor.ontime_back;
 
 import devkor.ontime_back.entity.ApiLog;
 import devkor.ontime_back.repository.ApiLogRepository;
+import devkor.ontime_back.response.GeneralException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
@@ -131,7 +132,12 @@ public class LoggingAspect {
         String clientIp = request.getRemoteAddr();
 
         // exceptionName
-        String exceptionName = ex.getClass().getSimpleName();
+        String exceptionName;
+        if (ex instanceof GeneralException) {
+            exceptionName = ((GeneralException) ex).getErrorCode().name();
+        } else {
+            exceptionName = ex.getClass().getSimpleName();
+        };
         // exceptionMessage
         String exceptionMessage = ex.getMessage();
         // responseStatus

--- a/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
@@ -16,10 +16,10 @@ public enum ErrorCode {
     SERVICE_UNAVAILABLE("503", "Service Unavailable: The server is temporarily unable to handle the request.", HttpStatus.SERVICE_UNAVAILABLE),
 
     // 비즈니스 로직 오류 코드
-    USER_NOT_FOUND("1001", "User Not Found: The specified user does not exist in the system.", HttpStatus.BAD_REQUEST),
-    INVALID_INPUT("1002", "Invalid Input: The input provided is invalid or not in the expected format.", HttpStatus.BAD_REQUEST),
-    RESOURCE_ALREADY_EXISTS("1003", "Resource Already Exists: The resource you are trying to create already exists.", HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED_ACCESS("1004", "Unauthorized Access: You do not have permission to perform this action.", HttpStatus.UNAUTHORIZED),
+    USER_NOT_FOUND("1001", "해당 ID의 사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_INPUT("1002", "유효하지 않은 입력값입니다.", HttpStatus.BAD_REQUEST),
+    RESOURCE_ALREADY_EXISTS("1003", "생성하려는 리소스가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED_ACCESS("1004", "해당 작업에 대한 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
     EMAIL_ALREADY_EXIST("1005", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
     NAME_ALREADY_EXIST("1006", "이미 존재하는 이름입니다.", HttpStatus.BAD_REQUEST),
     USER_SETTING_ALREADY_EXIST("1007", "이미 존재하는 userSettingId 입니다.", HttpStatus.BAD_REQUEST),
@@ -27,6 +27,8 @@ public enum ErrorCode {
     SAME_PASSWORD("1009", "새 비밀번호와 기존 비밀번호가 일치합니다.", HttpStatus.BAD_REQUEST),
     SCHEDULE_NOT_FOUND("1010", "해당 약속이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     FIREBASE("1011", "FIREBASE로 메세지를 발송하였으나 오류가 발생했습니다.(유효하지 않은 토큰 등)", HttpStatus.BAD_REQUEST),
+    FIRST_PREPARATION_NOT_FOUND("1012", "해당 ID의 사용자의 준비과정을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+
 
     // 공통 오류 메시지
     UNEXPECTED_ERROR("1000", "Unexpected Error: An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/ontime-back/src/main/java/devkor/ontime_back/response/GlobalExceptionHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/GlobalExceptionHandler.java
@@ -1,16 +1,20 @@
 package devkor.ontime_back.response;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<ApiResponseForm<String>> handleGeneralException(GeneralException e) {
+    public ResponseEntity<ApiResponseForm<Void>> handleGeneralException(GeneralException e) {
         // GeneralException에서 ErrorCode를 가져와 처리
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus())
@@ -18,10 +22,19 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(InvalidTokenException.class)
-    public ResponseEntity<ApiResponseForm<Void>> handleInvalidTokenException(InvalidTokenException ex) {
+    public ResponseEntity<ApiResponseForm<Void>> handleInvalidTokenException(InvalidTokenException ex, HttpServletRequest request) {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponseForm.error("401", ex.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponseForm<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex, HttpServletRequest request) {
+        log.error("[Error Log] requestUrl: {}, requestMethod: {}, userId: {}, clientIp: {}, exception: {}, message: {}, responseStatus: {}",
+                request.getRequestURI(), request.getMethod(), (request.getUserPrincipal() != null) ? request.getUserPrincipal().getName() : "Anonymous", request.getRemoteAddr(), "HttpMessageNotReadableException", "요청 형식이 올바르지 않습니다.", 400);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponseForm.error("400", "요청 형식이 올바르지 않습니다."));
     }
 
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/PreparationScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/PreparationScheduleService.java
@@ -7,11 +7,9 @@ import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.repository.PreparationScheduleRepository;
 import devkor.ontime_back.repository.ScheduleRepository;
 import devkor.ontime_back.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.servlet.http.HttpServletRequest;
+import devkor.ontime_back.response.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +18,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static devkor.ontime_back.response.ErrorCode.SCHEDULE_NOT_FOUND;
+import static devkor.ontime_back.response.ErrorCode.UNAUTHORIZED_ACCESS;
 
 @Service
 @Transactional(readOnly = true)
@@ -45,10 +46,10 @@ public class PreparationScheduleService {
     @Transactional
     protected void handlePreparationSchedules(Long userId, UUID scheduleId, List<PreparationDto> preparationDtoList, boolean shouldDelete) {
         Schedule schedule = scheduleRepository.findByIdWithUser(scheduleId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 일정을 찾을 수 없습니다: " + scheduleId));
+                .orElseThrow(() -> new GeneralException(SCHEDULE_NOT_FOUND));
 
         if (!schedule.getUser().getId().equals(userId)) {
-            throw new AccessDeniedException("사용자가 해당 일정에 대한 권한이 없습니다.");
+            throw new GeneralException(UNAUTHORIZED_ACCESS);
         }
 
         if (shouldDelete) {

--- a/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
@@ -7,6 +7,8 @@ import devkor.ontime_back.entity.User;
 import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.repository.PreparationUserRepository;
 import devkor.ontime_back.repository.UserRepository;
+import devkor.ontime_back.response.ErrorCode;
+import devkor.ontime_back.response.GeneralException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -16,19 +18,20 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static devkor.ontime_back.response.ErrorCode.*;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PreparationUserService {
     private final PreparationUserRepository preparationUserRepository;
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     // 회원가입 시 디폴트 준비과정 세팅
     public void setFirstPreparationUser(Long userId, List<PreparationDto> preparationDtoList) {
         User user = userRepository.findById(userId).orElseThrow(() ->
-                new EntityNotFoundException("사용자 ID " + userId + "에 해당하는 사용자를 찾을 수 없습니다.")
+                new GeneralException(USER_NOT_FOUND)
         );
         handlePreparationUsers(user, preparationDtoList, false);
 
@@ -38,7 +41,7 @@ public class PreparationUserService {
     @Transactional
     public void updatePreparationUsers(Long userId, List<PreparationDto> preparationDtoList) {
         User user = userRepository.findById(userId).orElseThrow(() ->
-                new EntityNotFoundException("사용자 ID " + userId + "에 해당하는 사용자를 찾을 수 없습니다.")
+                new GeneralException(USER_NOT_FOUND)
         );
         handlePreparationUsers(user, preparationDtoList, true);
 
@@ -48,7 +51,7 @@ public class PreparationUserService {
     public List<PreparationDto> showAllPreparationUsers(Long userId) {
 
         PreparationUser firstPreparation = preparationUserRepository.findFirstPreparationUserByUserIdWithNextPreparation(userId)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 ID " + userId + "에 대한 시작 준비 단계를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(FIRST_PREPARATION_NOT_FOUND));
 
         List<PreparationDto> preparationDtos = new ArrayList<>();
         PreparationUser current = firstPreparation;


### PR DESCRIPTION
### 수정한 코드
- `ErrorCode`: 비즈니스로직 에러메시지 수정
- `LoggingAspect`: errorlog에 `GeneralException`의 `exceptionName`으로 수정
- `GlobalExceptionHandler`: Dto에 잘못된 데이터타입으로 데이터가 들어온 경우 발생하는 `HttpMessageNotReadableException` 다루는 `exceptionhandler` 추가
- `PreparationScheduleService`, `PreparationUserService`, `ScheduleService`: `EntityNotFoundException`, `AccessDeniedException`와 같은 Exception을 `GeneralException`으로 처리 (Api 응답 통일 및 비즈니스 로직에서 발생하는 예외는 generalException으로 처리하는 것이 적절)

---

### 문제
- 특정 api로 요청하고 `GeneralException`에서 처리하지않는 예외가 발생할시, apiLog에서 `request.getRequestURI()`가 `/error`로 저장됨
- apiLog를 저장할 때, requestUrl이 `/error`로 나와 어느 api에서 에러가 발생한지 확인이 어려움

### 문제 이유
- Spring Boot에서는 내부적으로 Internal Server Error가 발생하면 요청 URL이 /error로 나옴
- Exception이 발생하면, Spring의 `BasicErrorController`가 /error 경로로 리디렉션하여 에러 페이지를 반환
-> request.getRequestURI()를 호출하면 /error가 반환될 수 있음

### 해결방법
- 비즈니스 로직 내부에서 발생한 `EntityNotFoundException`, .. 와 같은 exception을 `Generalexception` 으로 처리를 바꾸면 requestUrl이 사용한 메서드로 저장됨

---

### 추가적으로 수정한 부분
- dto가 유효하지 않아서 오는 에러는 `HttpMessageNotReadableException`로 컨트롤러 실행전에 발생하는 예외로, `AOP(LoggingAspect)`는 컨트롤러 메서드가 실행될 때 동작하기 때문에 컨트롤러 실행 전 예외는 `LoggingAspect`에서 감지되지 않음
- `ExceptionHandler`에서 errorllog 출력

---

### 결과
`AOP(LoggingAspect)`
: api request 로그, api error 중 내부 로직 exception 로그를 Db에 저장 및 출력

`ExceptionHandler`
: 컨트롤러 실행 전 예외는 로그로 출력