### PR TITLE
[mod] 여유시간이 null인 약속 조회시 사용자 디폴트 여유시간이 반환되도록 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/repository/ScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/ScheduleRepository.java
@@ -29,13 +29,13 @@ public interface ScheduleRepository extends JpaRepository<Schedule, UUID> {
     @Query("DELETE FROM Schedule s WHERE s.scheduleId = :scheduleId")
     void deleteByScheduleId(@Param("scheduleId") UUID scheduleId);
 
-    @Query("SELECT s FROM Schedule s JOIN FETCH s.place WHERE s.user.id = :userId")
+    @Query("SELECT s FROM Schedule s JOIN FETCH s.place JOIN FETCH s.user WHERE s.user.id = :userId")
     List<Schedule> findAllByUserIdWithPlace(Long userId);
-    @Query("SELECT s FROM Schedule s JOIN FETCH s.place WHERE s.user.id = :userId AND s.scheduleTime < :endDate")
+    @Query("SELECT s FROM Schedule s JOIN FETCH s.place JOIN FETCH s.user WHERE s.user.id = :userId AND s.scheduleTime < :endDate")
     List<Schedule> findAllByUserIdAndScheduleTimeBefore(@Param("userId") Long userId, @Param("endDate") LocalDateTime endDate);
-    @Query("SELECT s FROM Schedule s JOIN FETCH s.place WHERE s.user.id = :userId AND s.scheduleTime > :startDate")
+    @Query("SELECT s FROM Schedule s JOIN FETCH s.place JOIN FETCH s.user WHERE s.user.id = :userId AND s.scheduleTime > :startDate")
     List<Schedule> findAllByUserIdAndScheduleTimeAfter(@Param("userId") Long userId, @Param("startDate") LocalDateTime startDate);
-    @Query("SELECT s FROM Schedule s JOIN FETCH s.place WHERE s.user.id = :userId AND s.scheduleTime BETWEEN :startDate AND :endDate")
+    @Query("SELECT s FROM Schedule s JOIN FETCH s.place JOIN FETCH s.user WHERE s.user.id = :userId AND s.scheduleTime BETWEEN :startDate AND :endDate")
     List<Schedule> findAllByUserIdAndScheduleTimeBetween(@Param("userId") Long userId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
     // 특정 시간 범위 내에 시작되는 약속 조회

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -201,7 +201,7 @@ public class ScheduleService {
                 schedule.getScheduleName(),
                 schedule.getMoveTime(),
                 schedule.getScheduleTime(),
-                schedule.getScheduleSpareTime(),
+                (schedule.getScheduleSpareTime() == null) ? schedule.getUser().getSpareTime() : schedule.getScheduleSpareTime(),
                 schedule.getScheduleNote(),
                 schedule.getLatenessTime()
         );

--- a/ontime-back/src/test/java/devkor/ontime_back/service/FriendshipServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/FriendshipServiceTest.java
@@ -232,7 +232,7 @@ class FriendshipServiceTest {
         // when // then
         assertThatThrownBy(() -> friendshipService.getFriendShipRequester(addedReceiver.getId(), friendShip.getFriendShipId()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 친구 요청입니다. 친구 추가를 신청한 유저가 탈퇴했을 수 있습니다.");
+                .hasMessage("존재하지 않는 친구추가 요청자 id입니다. 해당 유저가 탈퇴했을 수 있습니다.");
     }
 
 


### PR DESCRIPTION
## 수정한 코드
- 여유시간이 null인 약속 조회시 사용자 디폴트 여유시간이 반환되도록 수정하였음.
- scheduleService의 mapToDto 메서드에서 3항 연산자를 이용해 약속의 여유시간이 null이면 사용자의 여유시간을 가져오게 코드 수정하였음.
- 이 때, 그냥 가져오게 되면 약속가져오는 쿼리 한 번, 해당 약속의 사용자 여유시간을 가져오는 쿼리 한번해서 총 2번 쿼리가 나가게 돼 응답시간에 손해를 봄. 따라서 처음에 약속을 조회할 때 사용자를 페치조인하여 가져오도록 코드 수정하였음
   - 약속 여유시간이 null이 아닌 약속은 유저와 페치조인을 할 필요가 없음에도 페치조인이 된다는 단점이 있으나, 
   처음 약속을 DB에서 가져오기 전에는 spareTime을 알 수 없어 위 단점은 필연적임.
   - **여유시간이 null인 약속들에 대해 쿼리 2번 날리기 vs 모든 약속에 대해 조인하기 중 차악을 선택해야하는 상황인데, 저는 우선 후자를 선택하였으나 이에 대한 고민을 같이 해주면 좋을 것 같습니다.**
     - 차후, 실 사용자가 생기면 여유시간을 설정하는 약속의 비율을 파악해 두 방법 중 어느 방법이 효율적일지 정확한 판단이 가능할 것같음.
     
## 테스트
DB에는 schedule_spare_time이 null로 저장된 약속을 조회하면 사용자 디폴트 시간이 여유시간으로 반환됨
<img width="954" alt="image" src="https://github.com/user-attachments/assets/f40b893a-4438-4199-af21-e56d9d106122" />

<img width="746" alt="image" src="https://github.com/user-attachments/assets/32c41f77-2e63-49c0-92a0-4b58499fc7d9" />

