### PR TITLE
[Mod] google 로그인 요청을 idtoken로 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthGoogleRequestDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthGoogleRequestDto.java
@@ -4,6 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class OAuthGoogleRequestDto {
-    private String accessToken;
+    private String idToken;
     private String refreshToken;
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthGoogleUserDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthGoogleUserDto.java
@@ -1,21 +1,19 @@
 package devkor.ontime_back.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 public class OAuthGoogleUserDto {
 
     private String id;           // 고유 사용자 ID
     private String name;          // 사용자 이름
-    @JsonProperty("given_name") // JSON의 given_name 필드와 매핑
-    private String givenName;
-    @JsonProperty("family_name") // JSON의 family_name 필드와 매핑
-    private String familyName;
     private String picture;       // 프로필 이미지 URL
     private String email;         // 이메일
-    @JsonProperty("email_verified")
-    private boolean emailVerified; // 이메일 인증 여부
 
+    public OAuthGoogleUserDto(String id, String name, String picture, String email) {
+        this.id = id;
+        this.name = name;
+        this.picture = picture;
+        this.email = email;
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginService.java
@@ -11,6 +11,7 @@ import devkor.ontime_back.entity.UserSetting;
 import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.global.jwt.JwtUtils;
 import devkor.ontime_back.repository.UserRepository;
+import devkor.ontime_back.response.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -156,16 +157,16 @@ public class AppleLoginService {
         Claims tokenClaims = jwtUtils.getTokenClaims(identityToken, publicKey);
         // iss 확인
         if (!issuer.equals(tokenClaims.getIssuer())) {
-            throw new IllegalArgumentException("유효하지 않은 JWT입니다. issuer가 일치하지 않습니다.");
+            throw new InvalidTokenException("유효하지 않은 JWT입니다. issuer가 일치하지 않습니다.");
         }
         // aud 확인
         if (!clientId.equals(tokenClaims.getAudience())) {
-            throw new IllegalArgumentException("유효하지 않은 JWT입니다. audience가 일치하지 않습니다.");
+            throw new InvalidTokenException("유효하지 않은 JWT입니다. audience가 일치하지 않습니다.");
         }
         // exp(만료 시간) 확인
         Date expiration = tokenClaims.getExpiration();
         if (expiration == null || expiration.before(Date.from(Instant.now()))) {
-            throw new IllegalArgumentException("유효하지 않은 JWT입니다. 만료되었습니다.");
+            throw new InvalidTokenException("유효하지 않은 JWT입니다. 만료되었습니다.");
         }
 
         return tokenClaims;


### PR DESCRIPTION
### 수정한 부분
- appleLoginService - userSettingId 저장 추가, Claim에서 exp 확인 추가
- OAuthGoogleUserDto - 사용하지 않는 정보 삭제
- OAuthGoogleRequestDto - accessToken이 아닌 idToken으로 수정
- GoogleLoginService - userSettingId 저장 추가, google idToken 인증 추가
- GoogleLoginFilter - idToken 인증 추가에 따른 코드 수정

**ID Token / Access Token**
- ID Token:  로그인 인증과 같이 사용자의 신원을 확인, Access Token: 특정 리소스(API)에 접근
- 자체서비스 JWT를 발급하기 때문에 구글 소셜로그인을 구현할때는 사용자가 정상적으로 로그인했는지를 검증할 수 있는 ID Token을 통해 인증을 받는 방법이 더 적합

---
### google 로그인 idtoken 검증 로직

**idtoken을 검증하기 위해 GoogleIdTokenVerifier 사용**

- GoogleIdTokenVerifier의 verify(identityToken)
```
public boolean verify(GoogleIdToken googleIdToken) throws GeneralSecurityException, IOException {
    if (!super.verifyPayload(googleIdToken)) {
        return false;
    } else {
	// Google 공개 키 가져옴
        Iterator var2 = this.publicKeys.getPublicKeys().iterator();

        PublicKey publicKey;
        do {
            if (!var2.hasNext()) {
                return false; // 일치하는 공개 키가 없으면 검증 실패
            }

            publicKey = (PublicKey)var2.next();
        } while(!googleIdToken.verifySignature(publicKey));

        return true; // 일치하는 공개 키가 있으면 true 반환 (검증 성공)
    }
}

```
- IdTokenVerifier의 verifyPayload(identityToken)
```
protected boolean verifyPayload(IdToken idToken) {
    boolean tokenPayloadValid = (this.issuers == null || idToken.verifyIssuer(this.issuers)) && (this.audience == null || idToken.verifyAudience(this.audience)) && idToken.verifyTime(this.clock.currentTimeMillis(), this.acceptableTimeSkewSeconds); // iss, aud, exp 검증
    return tokenPayloadValid;
}
```

---

### userSettingId 부분 추가

- 회원가입시 user의 userSettingId를 생성하고 default 세팅으로 저장하기 위해, handleRegister()에 userSettingId를 UUID로 생성한 후 저장하는 부분 추가
- 회원가입/로그인 확인이 백엔드에서 가능하여 프론트측에서 userSettingId를 받아오게 되면 로그인일때 불필요한 데이터를 받게 되기 때문에 백엔드에서 생성

close #181 