### PR TITLE
[mod&refact] 일반회원가입시 UUID 서버에서 생성하는 것으로 수정 및 회원가입코드 리팩토링

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/controller/UserAuthController.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/controller/UserAuthController.java
@@ -33,7 +33,7 @@ public class UserAuthController {
                     description = "회원가입 요청 JSON 데이터",
                     required = true,
                     content = @Content(
-                            schema = @Schema(type = "object", example = "{\"email\": \"user@example.com\", \"password\": \"password123\", \"name\": \"junbeom\", \"userSettingId\": \"a304cde3-8ee9-4054-971a-300aacc2177c\"}")
+                            schema = @Schema(type = "object", example = "{\"email\": \"user@example.com\", \"password\": \"password123\", \"name\": \"junbeom\"}")
                     )
             )
     )
@@ -48,17 +48,8 @@ public class UserAuthController {
     })
     @PostMapping("/sign-up")
     public ResponseEntity<ApiResponseForm<UserInfoResponse>> signUp(HttpServletRequest request, HttpServletResponse response, @RequestBody UserSignUpDto userSignUpDto) throws Exception {
-        User user = userAuthService.signUp(request, response, userSignUpDto);
+        UserInfoResponse userSignUpResponse = userAuthService.signUp(request, response, userSignUpDto);
         String message = "회원가입이 성공적으로 완료되었습니다. 온보딩을 진행해주세요( /user/onboarding )";
-        UserInfoResponse userSignUpResponse = UserInfoResponse.builder()
-                .userId(user.getId())
-                .name(user.getName())
-                .email(user.getEmail())
-                .role(user.getRole())
-                .spareTime(user.getSpareTime())
-                .note(user.getNote())
-                .punctualityScore(user.getPunctualityScore())
-                .build();
         return ResponseEntity.ok(ApiResponseForm.success(userSignUpResponse, message));
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserSignUpDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserSignUpDto.java
@@ -1,5 +1,6 @@
 package devkor.ontime_back.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,19 +8,12 @@ import lombok.NoArgsConstructor;
 import java.util.UUID;
 
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Builder
 public class UserSignUpDto {
     // 자체 로그인 회원 가입 API에 RequestBody로 사용할 UserSignUpDto를 생성
     private String email;
     private String password;
     private String name;
-    private UUID userSettingId;
-
-    @Builder
-    public UserSignUpDto(String email, String password, String name, UUID userSettingId) {
-        this.email = email;
-        this.password = password;
-        this.name = name;
-        this.userSettingId = userSettingId;
-    }
 }

--- a/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/controller/UserAuthControllerTest.java
@@ -5,6 +5,7 @@ import devkor.ontime_back.ControllerTestSupport;
 import devkor.ontime_back.TestSecurityConfig;
 import devkor.ontime_back.dto.ChangePasswordDto;
 import devkor.ontime_back.dto.UserAdditionalInfoDto;
+import devkor.ontime_back.dto.UserInfoResponse;
 import devkor.ontime_back.dto.UserSignUpDto;
 import devkor.ontime_back.entity.Role;
 import devkor.ontime_back.entity.User;
@@ -43,18 +44,16 @@ class UserAuthControllerTest extends ControllerTestSupport {
                 .email("user@example.com")
                 .name("junbeom")
                 .password("password123")
-                .userSettingId(UUID.fromString("a304cde3-8ee9-4054-971a-300aacc2177c"))
                 .build();
 
-        User mockUser = User.builder()
-                .id(1L)
-                .email("user@example.com")
+        UserInfoResponse userSignupResponse = UserInfoResponse.builder()
+                .userId(1L)
                 .name("junbeom")
-                .password("password123")
+                .email("user@example.com")
                 .role(Role.USER)
                 .build();
 
-        when(userAuthService.signUp(any(HttpServletRequest.class), any(HttpServletResponse.class),any(UserSignUpDto.class))).thenReturn(mockUser);
+        when(userAuthService.signUp(any(HttpServletRequest.class), any(HttpServletResponse.class),any(UserSignUpDto.class))).thenReturn(userSignupResponse);
 
         // when // then
         mockMvc.perform(


### PR DESCRIPTION
## 수정한 코드
- 일반 회원가입 시에도 UUID를 서버에서 생성하는 것으로 수정하였음
- 회원가입 코드 리팩토링을 진행하였음
  - (변경 전) 서비스계층에서 User 객체를 반환해 컨트롤러 계층에서 이를 Dto로 변환해서 반환했음
  (변경 후) 서비스계층에서 Dto를 만들어서 반환하고 컨트롤러는 받아서 그대로 반환
  - (변경 전) 서비스계층의 회원가입 코드가 내부메서드 없이 길게 전개됐음
  (변경 후) private 내부 메서드를 사용해 가독성을 높임 


## 확인해야할 사항
- 변경에 따라 테스트코드, Swagger 명세 수정하였음


Closed #186 
Closed #187 