### PR TITLE
[Refact] 알림 스케줄러 로직 변경 및 최적화

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="ontime@localhost" uuid="dc2c289a-7bab-4b46-8dd8-6cfb7f2de1df">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <remarks>$PROJECT_DIR$/ontime-back/src/main/resources/application.properties</remarks>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/ontime</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/.idea/modules/devkor.ontime-back.main.iml
+++ b/.idea/modules/devkor.ontime-back.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../ontime-back/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../ontime-back/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/.idea/modules/ontime-back.main.iml
+++ b/.idea/modules/ontime-back.main.iml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/sqlDataSources.xml
+++ b/.idea/sqlDataSources.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DdlMappings">
+    <mapping uuid="8e0a39f1-38ec-4e8e-b4f0-96c6843093a9" name="ontime@localhost Mapping">
+      <data-sources db="dc2c289a-7bab-4b46-8dd8-6cfb7f2de1df" />
+    </mapping>
+  </component>
+</project>

--- a/ontime-back/src/main/java/devkor/ontime_back/config/SchedulerConfig.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/SchedulerConfig.java
@@ -11,7 +11,7 @@ public class SchedulerConfig {
     @Bean
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(10);
+        scheduler.setPoolSize(20); // 필요시 더 늘릴 수 있음
         scheduler.setThreadNamePrefix("scheduler-");
         scheduler.initialize();
         return scheduler;

--- a/ontime-back/src/main/java/devkor/ontime_back/config/SchedulerConfig.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/SchedulerConfig.java
@@ -1,4 +1,19 @@
 package devkor.ontime_back.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
 public class SchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("scheduler-");
+        scheduler.initialize();
+        return scheduler;
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/config/SchedulerConfig.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/SchedulerConfig.java
@@ -1,0 +1,4 @@
+package devkor.ontime_back.config;
+
+public class SchedulerConfig {
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/config/SwaggerConfig.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/SwaggerConfig.java
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         servers = {
-                @Server(url = "https://ontime.devkor.club", description = "Production Server")
+                @Server(url = "https://ontime.devkor.club", description = "Production Server"),
+                @Server(url = "http://localhost:8080", description = "Local Serever")
         }
 )
 public class SwaggerConfig {

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
@@ -31,4 +31,10 @@ public class NotificationSchedule {
         this.isSent = isSent;
         this.schedule = schedule;
     }
+
+    public void changeStatusToSent() {
+        if(Boolean.FALSE.equals(this.isSent)) {
+            this.isSent = true;
+        }
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
@@ -45,4 +45,8 @@ public class NotificationSchedule {
     public void markAsUnsent() {
         this.isSent = false;
     }
+
+    public void disconnectSchedule() {
+        this.schedule = null;
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
@@ -1,0 +1,34 @@
+package devkor.ontime_back.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class NotificationSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime notificationTime;
+
+    private Boolean isSent;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    private Schedule schedule;
+
+    @Builder
+    public NotificationSchedule(LocalDateTime notificationTime, Boolean isSent, Schedule schedule) {
+        this.notificationTime = notificationTime;
+        this.isSent = isSent;
+        this.schedule = schedule;
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/NotificationSchedule.java
@@ -37,4 +37,12 @@ public class NotificationSchedule {
             this.isSent = true;
         }
     }
+
+    public void updateNotificationTime(LocalDateTime localDateTime) {
+        this.notificationTime = localDateTime;
+    }
+
+    public void markAsUnsent() {
+        this.isSent = false;
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
@@ -1,0 +1,4 @@
+package devkor.ontime_back.repository;
+
+public class NotificationScheduleRepository {
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
@@ -1,4 +1,18 @@
 package devkor.ontime_back.repository;
 
-public class NotificationScheduleRepository {
+import devkor.ontime_back.entity.NotificationSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface NotificationScheduleRepository extends JpaRepository<NotificationSchedule, Long> {
+    @Query("SELECT n FROM NotificationSchedule n " +
+            "JOIN FETCH n.schedule s " +
+            "JOIN FETCH s.user " +
+            "WHERE n.notificationTime > :now AND n.isSent = false")
+    List<NotificationSchedule> findAllWithScheduleAndUser(LocalDateTime now);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
@@ -18,5 +18,5 @@ public interface NotificationScheduleRepository extends JpaRepository<Notificati
             "WHERE n.notificationTime > :now AND n.isSent = false")
     List<NotificationSchedule> findAllWithScheduleAndUser(LocalDateTime now);
 
-    Optional<NotificationSchedule> findByScheduleId(UUID scheduleId);
+    Optional<NotificationSchedule> findByScheduleScheduleId(UUID scheduleId);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/NotificationScheduleRepository.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface NotificationScheduleRepository extends JpaRepository<NotificationSchedule, Long> {
@@ -15,4 +17,6 @@ public interface NotificationScheduleRepository extends JpaRepository<Notificati
             "JOIN FETCH s.user " +
             "WHERE n.notificationTime > :now AND n.isSent = false")
     List<NotificationSchedule> findAllWithScheduleAndUser(LocalDateTime now);
+
+    Optional<NotificationSchedule> findByScheduleId(UUID scheduleId);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
@@ -28,10 +28,10 @@ public enum ErrorCode {
     SCHEDULE_NOT_FOUND("1010", "해당 약속이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     FIREBASE("1011", "FIREBASE로 메세지를 발송하였으나 오류가 발생했습니다.(유효하지 않은 토큰 등)", HttpStatus.BAD_REQUEST),
     FIRST_PREPARATION_NOT_FOUND("1012", "해당 ID의 사용자의 준비과정을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-
+    NOTIFICATION_NOT_FOUND("1013", "알림을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST ),
 
     // 공통 오류 메시지
-    UNEXPECTED_ERROR("1000", "Unexpected Error: An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR);
+    UNEXPECTED_ERROR("1000", "Unexpected Error: An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR),;
 
     private final String code;
     private final String message;

--- a/ontime-back/src/main/java/devkor/ontime_back/scheduler/NotificationScheduler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/scheduler/NotificationScheduler.java
@@ -48,24 +48,5 @@ public class NotificationScheduler {
         List<Schedule> schedulesForToday = scheduleRepository.findSchedulesBetween(startOfToday, endOfToday);
         notificationService.sendReminder(schedulesForToday, "오늘 예정된 약속이 있습니다.");
     }
-
-//    @Scheduled(cron = "0 * * * * *")  // 매 분의 0초에 실행
-//    public void sendFiveMinutesBeforeReminder() {
-//        LocalDateTime baseTime = LocalDateTime.now().plusMinutes(5); // 현재 시간
-//        LocalDateTime startTime = baseTime.withSecond(0).withNano(0); // 초와 나노초 제거 (분 단위로 설정)
-//        LocalDateTime endTime = startTime.plusMinutes(1).minusNanos(1); // 다음 분의 직전까지
-//
-//        System.out.println("5분 후 시간: " + baseTime);
-//
-//        // 5분 후의 scheduleTime과 일치하는 약속 조회
-//        List<Schedule> schedulesStartingSoon = scheduleRepository.findSchedulesBetween(startTime, endTime);
-//
-//        for(Schedule schedule : schedulesStartingSoon) {
-//            System.out.println("5분 뒤의 약속: " + schedule.getScheduleName());
-//        }
-//
-//        // 알림 전송
-//        notificationService.sendReminder(schedulesStartingSoon, "약속 5분 전입니다. 준비하세요.");
-//    }
 }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/scheduler/NotificationScheduler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/scheduler/NotificationScheduler.java
@@ -49,23 +49,23 @@ public class NotificationScheduler {
         notificationService.sendReminder(schedulesForToday, "오늘 예정된 약속이 있습니다.");
     }
 
-    @Scheduled(cron = "0 * * * * *")  // 매 분의 0초에 실행
-    public void sendFiveMinutesBeforeReminder() {
-        LocalDateTime baseTime = LocalDateTime.now().plusMinutes(5); // 현재 시간
-        LocalDateTime startTime = baseTime.withSecond(0).withNano(0); // 초와 나노초 제거 (분 단위로 설정)
-        LocalDateTime endTime = startTime.plusMinutes(1).minusNanos(1); // 다음 분의 직전까지
-
-        System.out.println("5분 후 시간: " + baseTime);
-
-        // 5분 후의 scheduleTime과 일치하는 약속 조회
-        List<Schedule> schedulesStartingSoon = scheduleRepository.findSchedulesBetween(startTime, endTime);
-
-        for(Schedule schedule : schedulesStartingSoon) {
-            System.out.println("5분 뒤의 약속: " + schedule.getScheduleName());
-        }
-
-        // 알림 전송
-        notificationService.sendReminder(schedulesStartingSoon, "약속 5분 전입니다. 준비하세요.");
-    }
+//    @Scheduled(cron = "0 * * * * *")  // 매 분의 0초에 실행
+//    public void sendFiveMinutesBeforeReminder() {
+//        LocalDateTime baseTime = LocalDateTime.now().plusMinutes(5); // 현재 시간
+//        LocalDateTime startTime = baseTime.withSecond(0).withNano(0); // 초와 나노초 제거 (분 단위로 설정)
+//        LocalDateTime endTime = startTime.plusMinutes(1).minusNanos(1); // 다음 분의 직전까지
+//
+//        System.out.println("5분 후 시간: " + baseTime);
+//
+//        // 5분 후의 scheduleTime과 일치하는 약속 조회
+//        List<Schedule> schedulesStartingSoon = scheduleRepository.findSchedulesBetween(startTime, endTime);
+//
+//        for(Schedule schedule : schedulesStartingSoon) {
+//            System.out.println("5분 뒤의 약속: " + schedule.getScheduleName());
+//        }
+//
+//        // 알림 전송
+//        notificationService.sendReminder(schedulesStartingSoon, "약속 5분 전입니다. 준비하세요.");
+//    }
 }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/service/NotificationRecoveryService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/NotificationRecoveryService.java
@@ -1,0 +1,4 @@
+package devkor.ontime_back.service;
+
+public class NotificationRecoveryService {
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/service/NotificationRecoveryService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/NotificationRecoveryService.java
@@ -1,4 +1,36 @@
 package devkor.ontime_back.service;
 
+import devkor.ontime_back.entity.NotificationSchedule;
+import devkor.ontime_back.repository.NotificationScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class NotificationRecoveryService {
+
+    private final NotificationScheduleRepository notificationScheduleRepository;
+    private final NotificationService notificationService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void recoverNotificationSchedules() {
+        log.info("서버 부팅 완료: 알림 스케줄 복구 시작");
+
+        LocalDateTime now = LocalDateTime.now();
+        List<NotificationSchedule> pendingNotifications = notificationScheduleRepository.findAllWithScheduleAndUser(now);
+
+
+        for (NotificationSchedule notification : pendingNotifications) {
+            notificationService.scheduleReminder(notification);
+        }
+
+        log.info("알림 스케줄 복구 완료: 복구된 알림 수 = {}", pendingNotifications.size());
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
@@ -2,22 +2,65 @@ package devkor.ontime_back.service;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
+import devkor.ontime_back.entity.NotificationSchedule;
 import devkor.ontime_back.entity.Schedule;
 import devkor.ontime_back.entity.User;
 import devkor.ontime_back.entity.UserSetting;
+import devkor.ontime_back.repository.NotificationScheduleRepository;
 import devkor.ontime_back.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationService {
 
     private final UserSettingRepository userSettingRepository;
+    private final TaskScheduler taskScheduler;
+    private final NotificationScheduleRepository notificationScheduleRepository;
+
+    public void scheduleReminder(NotificationSchedule notificationSchedule) {
+        LocalDateTime reminderTime = notificationSchedule.getNotificationTime();
+
+        if (reminderTime.isBefore(LocalDateTime.now())) {
+            log.warn("약속 알림 시간이 과거인 경우 알림 스케줄링하지 않습니다. {} ({})", notificationSchedule.getSchedule().getScheduleName(), reminderTime);
+            return;
+        }
+
+        taskScheduler.schedule(
+                () -> {
+                    sendReminder(notificationSchedule, "약속 5분 전 입니다");
+                },
+                Date.from(reminderTime.atZone(ZoneId.systemDefault()).toInstant())
+        );
+        log.info("스케줄 등록 완료 {} ({})", notificationSchedule.getSchedule().getScheduleName(), reminderTime);
+    }
+
+    @Transactional
+    public void sendReminder(NotificationSchedule notificationSchedule, String message) {
+        Long userId = notificationSchedule.getSchedule().getUser().getId();
+
+        if (userId != null) {
+            UserSetting userSetting = userSettingRepository.findByUserId(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("No UserSetting found in schedule's user"));// Repository 메서드 가정
+
+            if (Boolean.TRUE.equals(userSetting.getIsNotificationsEnabled())) {
+                sendNotificationToUser(notificationSchedule.getSchedule(), message);
+                notificationSchedule.changeStatusToSent();
+                notificationScheduleRepository.save(notificationSchedule);
+            }
+        }
+    }
 
     public void sendReminder(List<Schedule> schedules, String message) {
         for (Schedule schedule : schedules) {
@@ -25,11 +68,9 @@ public class NotificationService {
             Long userId = user.getId();
 
             if (userId != null) {
-                // UserSetting 테이블에서 해당 유저의 알림 설정 가져오기
                 UserSetting userSetting = userSettingRepository.findByUserId(userId)
                         .orElseThrow(() -> new IllegalArgumentException("No UserSetting found in schedule's user"));// Repository 메서드 가정
 
-                // 알림 설정 확인
                 if (userSetting != null && userSetting.getIsNotificationsEnabled()) {
                     sendNotificationToUser(schedule, message);
                 }
@@ -37,7 +78,8 @@ public class NotificationService {
         }
     }
 
-    private void sendNotificationToUser(Schedule schedule, String message) {
+    @Transactional
+    public void sendNotificationToUser(Schedule schedule, String message) {
         User user = schedule.getUser();
         String firebaseToken = user.getFirebaseToken();
 
@@ -48,8 +90,8 @@ public class NotificationService {
                 .build();
 
         try {
-            String response = FirebaseMessaging.getInstance().send(firebaseMessage);
-            System.out.println("Firebase에 성공적으로 push notification 요청을 보냈으며, Firebase로부터 적절한 응답을 받았습니다 \n응답 내용:" + response);
+            FirebaseMessaging.getInstance().send(firebaseMessage);
+            log.info("Firebase에 성공적으로 push notification 요청을 보냈으며, Firebase로부터 적절한 응답을 받았습니다 \n알림 푸시한 약속:" + schedule.getScheduleName());
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
@@ -11,6 +11,8 @@ import devkor.ontime_back.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 
 @Slf4j
+@EnableAsync
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -59,6 +62,7 @@ public class NotificationService {
         }
     }
 
+    @Async
     @Transactional
     public void sendReminder(NotificationSchedule notificationSchedule, String message) {
         Long userId = notificationSchedule.getSchedule().getUser().getId();

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -128,6 +128,8 @@ public class ScheduleService {
     }
 
     private void updateAndRescheduleNotification(LocalDateTime newNotificationTime, NotificationSchedule notification) {
+        if(newNotificationTime == notification.getNotificationTime()) return;
+
         notificationService.cancelScheduledNotification(notification.getId());
         notification.updateNotificationTime(newNotificationTime);
         notification.markAsUnsent();

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -97,6 +97,7 @@ public class ScheduleService {
     private void cancleAndDeleteNotification(NotificationSchedule notification) {
         notificationService.cancelScheduledNotification(notification.getId());
         notificationScheduleRepository.delete(notification);
+        log.info("{}에 대한 알림 취소 및 삭제 됨", notification.getSchedule().getScheduleName()t);
     }
 
     // schedule 수정
@@ -120,16 +121,17 @@ public class ScheduleService {
 
         NotificationSchedule notification = notificationScheduleRepository.findByScheduleScheduleId(scheduleId)
                 .orElseThrow(() -> new GeneralException(NOTIFICATION_NOT_FOUND));
-
-        updateAndRescheduleNotification(scheduleModDto, notification);
+        LocalDateTime newNotificationTime = scheduleModDto.getScheduleTime().minusMinutes(5);
+        updateAndRescheduleNotification(newNotificationTime, notification);
     }
 
-    private void updateAndRescheduleNotification(ScheduleModDto scheduleModDto, NotificationSchedule notification) {
+    private void updateAndRescheduleNotification(LocalDateTime newNotificationTime, NotificationSchedule notification) {
         notificationService.cancelScheduledNotification(notification.getId());
-        notification.updateNotificationTime(scheduleModDto.getScheduleTime().minusMinutes(5));
+        notification.updateNotificationTime(newNotificationTime);
         notification.markAsUnsent();
         notificationScheduleRepository.save(notification);
         notificationService.scheduleReminder(notification);
+        log.info("{}에 대한 알림정보 업데이트되고 스케줄링 계획도 리스케줄됨", notification.getSchedule().getScheduleName());
     }
 
     // schedule 추가

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -1,6 +1,7 @@
 package devkor.ontime_back.service;
 
 import devkor.ontime_back.dto.*;
+import devkor.ontime_back.entity.NotificationSchedule;
 import devkor.ontime_back.entity.Place;
 import devkor.ontime_back.entity.Schedule;
 import devkor.ontime_back.entity.User;
@@ -33,6 +34,7 @@ public class ScheduleService {
     private final PlaceRepository placeRepository;
     private final PreparationScheduleRepository preparationScheduleRepository;
     private final PreparationUserRepository preparationUserRepository;
+    private final NotificationScheduleRepository notificationScheduleRepository;
 
     // scheduleId, userId를 통한 권한 확인
     private Schedule getScheduleWithAuthorization(UUID scheduleId, Long userId) {
@@ -127,10 +129,16 @@ public class ScheduleService {
                 .isStarted(false)
                 .latenessTime(-1)
                 .build();
-
         scheduleRepository.save(schedule);
 
-        notificationService.scheduleReminder(schedule);
+        NotificationSchedule notification = NotificationSchedule.builder()
+                .notificationTime(schedule.getScheduleTime().minusMinutes(5)) // 차후 알림보내야하는 시각으로 수정 필요
+                .isSent(false)
+                .schedule(schedule)
+                .build();
+        notificationScheduleRepository.save(notification);
+
+        notificationService.scheduleReminder(notification);
     }
 
     // 지각 히스토리 반환

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -85,7 +85,7 @@ public class ScheduleService {
     @Transactional
     public void deleteSchedule(UUID scheduleId, Long userId) {
         Schedule schedule = getScheduleWithAuthorization(scheduleId, userId);
-        NotificationSchedule notification = notificationScheduleRepository.findByScheduleId(scheduleId)
+        NotificationSchedule notification = notificationScheduleRepository.findByScheduleScheduleId(scheduleId)
                 .orElseThrow(() -> new GeneralException(NOTIFICATION_NOT_FOUND));
 
         cancleAndDeleteNotification(notification);
@@ -118,7 +118,7 @@ public class ScheduleService {
         scheduleRepository.save(schedule);
 
 
-        NotificationSchedule notification = notificationScheduleRepository.findByScheduleId(scheduleId)
+        NotificationSchedule notification = notificationScheduleRepository.findByScheduleScheduleId(scheduleId)
                 .orElseThrow(() -> new GeneralException(NOTIFICATION_NOT_FOUND));
 
         updateAndRescheduleNotification(scheduleModDto, notification);

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -97,7 +97,7 @@ public class ScheduleService {
     private void cancleAndDeleteNotification(NotificationSchedule notification) {
         notificationService.cancelScheduledNotification(notification.getId());
         notificationScheduleRepository.delete(notification);
-        log.info("{}에 대한 알림 취소 및 삭제 됨", notification.getSchedule().getScheduleName()t);
+        log.info("{}에 대한 알림 취소 및 삭제 됨", notification.getSchedule().getScheduleName());
     }
 
     // schedule 수정

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -26,6 +26,7 @@ import static devkor.ontime_back.response.ErrorCode.*;
 public class ScheduleService {
 
     private final UserService userService;
+    private final NotificationService notificationService;
 
     private final ScheduleRepository scheduleRepository;
     private final UserRepository userRepository;
@@ -128,6 +129,8 @@ public class ScheduleService {
                 .build();
 
         scheduleRepository.save(schedule);
+
+        notificationService.scheduleReminder(schedule);
     }
 
     // 지각 히스토리 반환

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -89,15 +89,17 @@ public class ScheduleService {
                 .orElseThrow(() -> new GeneralException(NOTIFICATION_NOT_FOUND));
 
         cancleAndDeleteNotification(notification);
-
+        notificationScheduleRepository.flush();
         preparationScheduleRepository.deleteBySchedule(schedule);
         scheduleRepository.deleteByScheduleId(scheduleId);
     }
 
     private void cancleAndDeleteNotification(NotificationSchedule notification) {
+        log.info("{}에 대한 알림 취소 및 삭제 됨", notification.getSchedule().getScheduleName());
+        notification.disconnectSchedule();
         notificationService.cancelScheduledNotification(notification.getId());
         notificationScheduleRepository.delete(notification);
-        log.info("{}에 대한 알림 취소 및 삭제 됨", notification.getSchedule().getScheduleName());
+        log.info("알림 삭제 완료");
     }
 
     // schedule 수정

--- a/ontime-back/src/main/resources/db/migration/V2__create_notification_schedule.sql
+++ b/ontime-back/src/main/resources/db/migration/V2__create_notification_schedule.sql
@@ -1,0 +1,10 @@
+CREATE TABLE notification_schedule (
+                                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                       notification_time TIMESTAMP,
+                                       is_sent BOOLEAN,
+                                       schedule_id BINARY(16),
+                                       CONSTRAINT fk_notification_schedule_schedule
+                                          FOREIGN KEY (schedule_id)
+                                          REFERENCES schedule (schedule_id)
+                                          ON DELETE CASCADE
+);

--- a/ontime-back/src/test/java/devkor/ontime_back/service/ScheduleServiceTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/service/ScheduleServiceTest.java
@@ -47,6 +47,8 @@ class ScheduleServiceTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+    @Autowired
+    private NotificationScheduleRepository notificationScheduleRepository;
 
     @AfterEach
     void tearDown() {
@@ -647,8 +649,13 @@ class ScheduleServiceTest {
                 .place(place1)
                 .user(newUser)
                 .build();
-
+        NotificationSchedule notificationSchedule = NotificationSchedule.builder()
+                .notificationTime(LocalDateTime.of(2025, 2, 23, 6, 55))
+                .isSent(false)
+                .schedule(addedSchedule1)
+                .build();
         scheduleRepository.save(addedSchedule1);
+        notificationScheduleRepository.save(notificationSchedule);
 
         // when
         scheduleService.deleteSchedule(addedSchedule1.getScheduleId(), newUser.getId());
@@ -799,6 +806,12 @@ class ScheduleServiceTest {
                 .scheduleSpareTime(5)
                 .latenessTime(10)
                 .build();
+        NotificationSchedule notificationSchedule = NotificationSchedule.builder()
+                .notificationTime(LocalDateTime.of(2025, 2, 23, 6, 55))
+                .isSent(false)
+                .schedule(addedSchedule1)
+                .build();
+        notificationScheduleRepository.save(notificationSchedule);
 
         // when
         scheduleService.modifySchedule(newUser.getId(), addedSchedule1.getScheduleId(), scheduleModDto);
@@ -859,6 +872,12 @@ class ScheduleServiceTest {
                 .scheduleSpareTime(5)
                 .latenessTime(10)
                 .build();
+        NotificationSchedule notificationSchedule = NotificationSchedule.builder()
+                .notificationTime(LocalDateTime.of(2025, 2, 23, 6, 55))
+                .isSent(false)
+                .schedule(addedSchedule1)
+                .build();
+        notificationScheduleRepository.save(notificationSchedule);
 
         // when
         scheduleService.modifySchedule(newUser.getId(), scheduleId, scheduleModDto);


### PR DESCRIPTION
## 작업 배경
기존에는 매 분마다 
`Select * from schedule where time=현재시각+5분`
위 쿼리를 실행 해 모든 약속을 순회하며 5분뒤의 약속을 조회했었음.
즉, 약속이 없는 시각에도 불필요하게 스케줄링 작업을 실행하여 메모리를 낭비했었음.

따라서 약속 생성 시점에 알림을 동적으로 등록하여 이후에는 따로 약속을 스캔할 필요 없이 스케줄링이 되게 로직을 변경하였고, 그 과정에서 알림테이블 생성, 비동기 처리 등 최적화 작업을 진행하였음.

## 주요 변경사항
- 알림을 동적으로 스케줄링
  - (변경 전) @Scheduled 애너테이션을 활용해 매분마다 모든 약속을 스캔하여 알림 푸시
  - (변경 후) 약속 생성할 때 TaskScheduler를 이용해 알림스케줄링계획을 동적으로 등록해 TaskScheduler가 해당 시각이 되면 자동으로 알림 푸시
  - 불필요한 메모리 낭비, 데이터 스캔이 줄어듦
- NotificationSchedule 테이블 생성
  - TaskScheduler를 통해 동적으로 등록된 알림스케줄은 WAS가 재시작되면 정보가 소실됨. 따라서 WAS가 재시작됐을 때 DB에서 등록된 알림정보를 불러오기 위해 NotificationSchedule 테이블을 생성하였음.
  - 이 때 서버 재시작시 불러온 NotificationSchedule 데이터에 Schedule이 LazyLoading설정 돼있어, LazyInitializationException이 발생할 수 있어 페치조인으로 방지하였음.
- TaskScheduler에는 알림스케줄이 Map형태로 저장됨.
  - 약속을 수정하거나 삭제하면 동적으로 등록됐던 스케줄을 수정해줘야하는데 이 때 Map으로 저장해야만 등록했던 알림스케줄을 가져와 수정/삭제할 수 있음.
- 알림발송메서드 비동기처리 및 TaskScheduler 다중 스레드 설정
  - 특정 시간에 여러 알림스케줄이 몰려 병목이 일어나는 것을 방지하고자 비동기+다중스레드 처리를 하여 병렬로 실행될 수 있게하였음.
  - 이게 작동하는지, 얼마나 시간을 세이브하는지에 대해서는 테스트가 필요함. 차후 반드시 진행할 예정. 

Closed #212 