### PR TITLE
[Refact] API 로그 저장 비동기 처리 및 최적화

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
@@ -1,9 +1,12 @@
 package devkor.ontime_back;
 
+import devkor.ontime_back.dto.RequestInfoDto;
 import devkor.ontime_back.entity.ApiLog;
 import devkor.ontime_back.repository.ApiLogRepository;
 import devkor.ontime_back.response.GeneralException;
+import devkor.ontime_back.service.ApiLogService;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -13,48 +16,36 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 
 @Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class LoggingAspect {
 
-    private final ApiLogRepository apiLogRepository;
-
-    public LoggingAspect(ApiLogRepository apiLogRepository) {
-        this.apiLogRepository = apiLogRepository;
-    }
-
+    private final ApiLogService apiLogService;
+    private static final String NO_PARAMS = "No Params";
+    private static final String NO_BODY = "No Body";
 
     @Pointcut("bean(*Controller)")
     private void allRequest() {}
 
     @Around("allRequest()")
     public Object logRequest(ProceedingJoinPoint joinPoint) throws Throwable {
-
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-
-        // requestUrl
-        String requestUrl = request.getRequestURI();
-        // requestMethod
-        String requestMethod = request.getMethod();
-        // userId
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String userId = (authentication != null && authentication.isAuthenticated())
-                ? authentication.getName() // 인증된 사용자의 이름 (주로 ID로 사용됨)
-                : "Anonymous";
-        // clientIp
-        String clientIp = request.getRemoteAddr();
+        RequestInfoDto requestInfoDto = extractRequestInfo();
 
         // requestTime
         long beforeRequest = System.currentTimeMillis();
@@ -91,21 +82,14 @@ public class LoggingAspect {
 
             // 정상 요청 로그 저장
             long timeTaken = System.currentTimeMillis() - beforeRequest;
-            ApiLog apiLog = ApiLog.builder().
-                    requestUrl(requestUrl).
-                    requestMethod(requestMethod).
-                    userId(userId).
-                    clientIp(clientIp).
-                    responseStatus(responseStatus).
-                    takenTime(timeTaken).
-                    build();
 
-            apiLogRepository.save(apiLog);
+            ApiLog apiLog = buildApiLog(requestInfoDto, responseStatus, timeTaken);
+            apiLogService.saveLog(apiLog);
 
             log.info("[Request Log] requestUrl: {}, requestMethod: {}, userId: {}, clientIp: {}, pathVariable: {}, requestBody: {}, responseStatus: {}, timeTaken: {}",
-                    requestUrl, requestMethod, userId, clientIp,
-                    pathVariable != null ? pathVariable : "No Params",
-                    requestBody != null ? requestBody : "No Body",
+                    requestInfoDto.getRequestUrl(), requestInfoDto.getRequestMethod(), requestInfoDto.getUserId(), requestInfoDto.getClientIp(),
+                    pathVariable != null ? pathVariable : NO_PARAMS,
+                    requestBody != null ? requestBody : NO_BODY,
                     responseStatus, timeTaken);
 
             return result;
@@ -117,19 +101,7 @@ public class LoggingAspect {
 
     @AfterThrowing(pointcut = "allRequest()", throwing = "ex")
     public void logException(JoinPoint joinPoint, Exception ex) {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-
-        // requestUrl
-        String requestUrl = request.getRequestURI();
-        // requestMethod
-        String requestMethod = request.getMethod();
-        // userId
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String userId = (authentication != null && authentication.isAuthenticated())
-                ? authentication.getName() // 인증된 사용자의 이름 (주로 ID로 사용됨)
-                : "Anonymous";
-        // clientIp
-        String clientIp = request.getRemoteAddr();
+        RequestInfoDto requestInfoDto = extractRequestInfo();
 
         // exceptionName
         String exceptionName;
@@ -144,32 +116,48 @@ public class LoggingAspect {
         int responseStatus = mapExceptionToStatusCode(ex);
 
         log.error("[Error Log] requestUrl: {}, requestMethod: {}, userId: {}, clientIp: {}, exception: {}, message: {}, responseStatus: {}",
-                requestUrl, requestMethod, userId, clientIp, exceptionName, exceptionMessage, responseStatus);
+                requestInfoDto.getRequestUrl(), requestInfoDto.getRequestMethod(), requestInfoDto.getUserId(), requestInfoDto.getClientIp(), exceptionName, exceptionMessage, responseStatus);
 
-        // DB에 에러 로그 저장
-        ApiLog errorLog = ApiLog.builder().
-                requestUrl(requestUrl).
-                requestMethod(requestMethod).
-                userId(userId).
-                clientIp(clientIp).
-                responseStatus(responseStatus).
-                takenTime(0).
-                build();
-         // 상태 코드와 시간은 예제로 설정
-        apiLogRepository.save(errorLog);
+        ApiLog errorLog = buildApiLog(requestInfoDto, responseStatus, 0);
+        apiLogService.saveLog(errorLog);
     }
+
+    // requestinfo 추출
+    private RequestInfoDto extractRequestInfo() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String requestUrl = request.getRequestURI();
+        String requestMethod = request.getMethod();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = (authentication != null && authentication.isAuthenticated())
+                ? authentication.getName()
+                : "Anonymous";
+        String clientIp = request.getRemoteAddr();
+
+        return new RequestInfoDto(requestUrl, requestMethod, userId, clientIp);
+    }
+
+    // apilog 생성
+    private ApiLog buildApiLog(RequestInfoDto info, int responseStatus, long timeTaken) {
+        return ApiLog.builder()
+                .requestUrl(info.getRequestUrl())
+                .requestMethod(info.getRequestMethod())
+                .userId(info.getUserId())
+                .clientIp(info.getClientIp())
+                .responseStatus(responseStatus)
+                .takenTime(timeTaken)
+                .build();
+    }
+
+    // Exception 매핑
+    private static final Map<Class<? extends Exception>, Integer> EXCEPTION_STATUS_MAP = Map.of(
+            IllegalArgumentException.class, 400,
+            AccessDeniedException.class, 403,
+            MethodArgumentNotValidException.class, 422
+    );
 
     private int mapExceptionToStatusCode(Exception e) {
-        if (e instanceof IllegalArgumentException) {
-            return 400; // Bad Request
-        } else if (e instanceof org.springframework.security.access.AccessDeniedException) {
-            return 403; // Forbidden
-        } else if (e instanceof org.springframework.web.bind.MethodArgumentNotValidException) {
-            return 422; // Unprocessable Entity
-        } else {
-            return 500; // Internal Server Error
-        }
+        return EXCEPTION_STATUS_MAP.getOrDefault(e.getClass(), 500);
     }
-
 
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
@@ -149,15 +149,11 @@ public class LoggingAspect {
                 .build();
     }
 
-    // Exception 매핑
-    private static final Map<Class<? extends Exception>, Integer> EXCEPTION_STATUS_MAP = Map.of(
-            IllegalArgumentException.class, 400,
-            AccessDeniedException.class, 403,
-            MethodArgumentNotValidException.class, 422
-    );
-
     private int mapExceptionToStatusCode(Exception e) {
-        return EXCEPTION_STATUS_MAP.getOrDefault(e.getClass(), 500);
+        if (e instanceof GeneralException ge) {
+            return ge.getErrorCode().getCode();
+        }
+        return 500;
     }
 
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/OntimeBackApplication.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/OntimeBackApplication.java
@@ -2,8 +2,10 @@ package devkor.ontime_back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @SpringBootApplication
 @EnableScheduling
 public class OntimeBackApplication {

--- a/ontime-back/src/main/java/devkor/ontime_back/config/SwaggerConfig.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @OpenAPIDefinition(
         servers = {
-                @Server(url = "https://ontime.devkor.club", description = "Production Server"),
+                @Server(url = "https://api.ontime.devkor.club", description = "Production Server"),
                 @Server(url = "http://localhost:8080", description = "Local Serever")
         }
 )

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/RequestInfoDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/RequestInfoDto.java
@@ -1,0 +1,14 @@
+package devkor.ontime_back.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RequestInfoDto {
+    private String requestUrl;
+    private String requestMethod;
+    private String userId;
+    private String clientIp;
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/response/ApiResponseForm.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/ApiResponseForm.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 public class ApiResponseForm<T> {
     // 제네릭 api 응답 객체
     private String status;
-    private String code;
+    private int code;
     private String message;
     private final T data;
-    public ApiResponseForm(String status, String code, String message, T data) {
+    public ApiResponseForm(String status, int code, String message, T data) {
         this.status = status; // HttpResponse의 생성자 호출 (부모 클래스의 생성자 또는 메서드를 호출, 자식 클래스는 부모 클래스의 private 필드에 직접 접근 X)
         this.code = code;
         this.message = message;
@@ -20,33 +20,33 @@ public class ApiResponseForm<T> {
 
     // 성공 응답을 위한 메서드 (message를 받는 경우)
     public static <T> ApiResponseForm<T> success(T data, String message) {
-        return new ApiResponseForm<>("success", "200", message, data);
+        return new ApiResponseForm<>("success", 200, message, data);
     }
 
     // 성공 응답을 위한 메서드 (message를 받지 않는 경우)
     public static <T> ApiResponseForm<T> success(T data) {
-        return new ApiResponseForm<>("success", "200", "OK", data);
+        return new ApiResponseForm<>("success", 200, "OK", data);
     }
 
     // 실패 응답을 위한 메서드
-    public static <T> ApiResponseForm<T> fail(String code, String message) {
+    public static <T> ApiResponseForm<T> fail(int code, String message) {
         return new ApiResponseForm<>("fail", code, message, null);  // 실패의 경우 data는 null로 처리
     }
 
-    public static <T> ApiResponseForm<T> accessTokenEmpty(String code, String message) {
+    public static <T> ApiResponseForm<T> accessTokenEmpty(int code, String message) {
         return new ApiResponseForm<>("accessTokenEmpty", code, message, null);  // 실패의 경우 data는 null로 처리
     }
 
-    public static <T> ApiResponseForm<T> accessTokenInvalid(String code, String message) {
+    public static <T> ApiResponseForm<T> accessTokenInvalid(int code, String message) {
         return new ApiResponseForm<>("accessTokenInvalid", code, message, null);  // 실패의 경우 data는 null로 처리
     }
 
-    public static <T> ApiResponseForm<T> refreshTokenInvalid(String code, String message) {
+    public static <T> ApiResponseForm<T> refreshTokenInvalid(int code, String message) {
         return new ApiResponseForm<>("refreshTokenInvalid", code, message, null);  // 실패의 경우 data는 null로 처리
     }
 
     // 오류 응답을 위한 메서드
-    public static <T> ApiResponseForm<T> error(String code, String message) {
+    public static <T> ApiResponseForm<T> error(int code, String message) {
         return new ApiResponseForm<>("error", code, message, null);  // 오류의 경우 data는 null로 처리
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
@@ -5,47 +5,47 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // HTTP 상태 코드 (4xx)
-    BAD_REQUEST("400", "Bad Request: Invalid input or malformed request.", HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED("401", "Unauthorized: You must authenticate to access this resource.", HttpStatus.UNAUTHORIZED),
-    FORBIDDEN("403", "Forbidden: You do not have permission to access this resource.", HttpStatus.FORBIDDEN),
-    NOT_FOUND("404", "Not Found: The requested resource could not be found.", HttpStatus.NOT_FOUND),
+    BAD_REQUEST(400, "Bad Request: Invalid input or malformed request.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED(401, "Unauthorized: You must authenticate to access this resource.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN(403, "Forbidden: You do not have permission to access this resource.", HttpStatus.FORBIDDEN),
+    NOT_FOUND(404, "Not Found: The requested resource could not be found.", HttpStatus.NOT_FOUND),
 
     // HTTP 상태 코드 (5xx)
-    INTERNAL_SERVER_ERROR("500", "Internal Server Error: An unexpected error occurred on the server.", HttpStatus.INTERNAL_SERVER_ERROR),
-    BAD_GATEWAY("502", "Bad Gateway: The server received an invalid response from the upstream server.", HttpStatus.BAD_GATEWAY),
-    SERVICE_UNAVAILABLE("503", "Service Unavailable: The server is temporarily unable to handle the request.", HttpStatus.SERVICE_UNAVAILABLE),
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error: An unexpected error occurred on the server.", HttpStatus.INTERNAL_SERVER_ERROR),
+    BAD_GATEWAY(502, "Bad Gateway: The server received an invalid response from the upstream server.", HttpStatus.BAD_GATEWAY),
+    SERVICE_UNAVAILABLE(503, "Service Unavailable: The server is temporarily unable to handle the request.", HttpStatus.SERVICE_UNAVAILABLE),
 
     // 비즈니스 로직 오류 코드
-    USER_NOT_FOUND("1001", "해당 ID의 사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_INPUT("1002", "유효하지 않은 입력값입니다.", HttpStatus.BAD_REQUEST),
-    RESOURCE_ALREADY_EXISTS("1003", "생성하려는 리소스가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED_ACCESS("1004", "해당 작업에 대한 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
-    EMAIL_ALREADY_EXIST("1005", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
-    NAME_ALREADY_EXIST("1006", "이미 존재하는 이름입니다.", HttpStatus.BAD_REQUEST),
-    USER_SETTING_ALREADY_EXIST("1007", "이미 존재하는 userSettingId 입니다.", HttpStatus.BAD_REQUEST),
-    PASSWORD_INCORRECT("1008", "기존 비밀번호가 틀렸습니다.", HttpStatus.BAD_REQUEST),
-    SAME_PASSWORD("1009", "새 비밀번호와 기존 비밀번호가 일치합니다.", HttpStatus.BAD_REQUEST),
-    SCHEDULE_NOT_FOUND("1010", "해당 약속이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
-    FIREBASE("1011", "FIREBASE로 메세지를 발송하였으나 오류가 발생했습니다.(유효하지 않은 토큰 등)", HttpStatus.BAD_REQUEST),
-    FIRST_PREPARATION_NOT_FOUND("1012", "해당 ID의 사용자의 준비과정을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-    NOTIFICATION_NOT_FOUND("1013", "알림을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST ),
+    USER_NOT_FOUND(1001, "해당 ID의 사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_INPUT(1002, "유효하지 않은 입력값입니다.", HttpStatus.BAD_REQUEST),
+    RESOURCE_ALREADY_EXISTS(1003, "생성하려는 리소스가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED_ACCESS(1004, "해당 작업에 대한 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
+    EMAIL_ALREADY_EXIST(1005, "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
+    NAME_ALREADY_EXIST(1006, "이미 존재하는 이름입니다.", HttpStatus.BAD_REQUEST),
+    USER_SETTING_ALREADY_EXIST(1007, "이미 존재하는 userSettingId 입니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_INCORRECT(1008, "기존 비밀번호가 틀렸습니다.", HttpStatus.BAD_REQUEST),
+    SAME_PASSWORD(1009, "새 비밀번호와 기존 비밀번호가 일치합니다.", HttpStatus.BAD_REQUEST),
+    SCHEDULE_NOT_FOUND(1010, "해당 약속이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    FIREBASE(1011, "FIREBASE로 메세지를 발송하였으나 오류가 발생했습니다.(유효하지 않은 토큰 등)", HttpStatus.BAD_REQUEST),
+    FIRST_PREPARATION_NOT_FOUND(1012, "해당 ID의 사용자의 준비과정을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NOTIFICATION_NOT_FOUND(1013, "알림을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST ),
 
     // 공통 오류 메시지
-    UNEXPECTED_ERROR("1000", "Unexpected Error: An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR),;
+    UNEXPECTED_ERROR(1000, "Unexpected Error: An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR),;
 
-    private final String code;
+    private final int code;
     private final String message;
     private final HttpStatus httpStatus;
 
     // 생성자
-    ErrorCode(String code, String message, HttpStatus httpStatus) {
+    ErrorCode(int code, String message, HttpStatus httpStatus) {
         this.code = code;
         this.message = message;
         this.httpStatus = httpStatus;
     }
 
     // 코드와 메시지를 반환하는 메서드
-    public String getCode() {
+    public int getCode() {
         return code;
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/response/GlobalExceptionHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponseForm<Void>> handleInvalidTokenException(InvalidTokenException ex, HttpServletRequest request) {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponseForm.error("401", ex.getMessage()));
+                .body(ApiResponseForm.error(401, ex.getMessage()));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
                 request.getRequestURI(), request.getMethod(), (request.getUserPrincipal() != null) ? request.getUserPrincipal().getName() : "Anonymous", request.getRemoteAddr(), "HttpMessageNotReadableException", "요청 형식이 올바르지 않습니다.", 400);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponseForm.error("400", "요청 형식이 올바르지 않습니다."));
+                .body(ApiResponseForm.error(400, "요청 형식이 올바르지 않습니다."));
     }
 
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ApiLogService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ApiLogService.java
@@ -1,0 +1,26 @@
+package devkor.ontime_back.service;
+
+import devkor.ontime_back.entity.ApiLog;
+import devkor.ontime_back.repository.ApiLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ApiLogService {
+    private final ApiLogRepository apiLogRepository;
+
+    @Async
+    public void saveLog(ApiLog apiLog) {
+        try {
+            log.info("[Async] saveLog started on thread: {}", Thread.currentThread().getName());
+            apiLogRepository.save(apiLog);
+            log.info("[Async] saveLog finished on thread: {}", Thread.currentThread().getName());
+        } catch (Exception e) {
+            log.error("API 로그 저장 실패", e);
+        }
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/NotificationService.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 
 @Slf4j
-@EnableAsync
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)


### PR DESCRIPTION
### 수정한 부분
- @EnableAsync 어노테이션 위치 변경 (NotificationService -> SpingApplication)
  - @EnableAsync - 스프링에게 "Async 기능을 전역으로 활성화하라"고 지시. 없으면 @Async를 붙여도 작동 X
  - config나 application 위치에 설정 (notificationservice에서도 사용하나 전체적으로 관리하도록 함)
- loggingAspect 메서드 분리
  - RequestInfoDto를 사용해서 logRequest랑 logException 메서드 안에 requestUrl, requestMethod, userId, clientIp 가져오는 코드 중복 제거
  - Map 자료구조를 써서 “예외 클래스 -> 상태 코드”를 미리 저장
- API 로그 저장 비동기 처리로 성능 최적화
  - 사용자는 로그 저장 여부보다 빠른 응답을 더 중요하게 여김 -> @Async를 활용해 로그 저장을 비동기 처리하도록 변경
  - @Async의 동작 원리(프록시 구조를 통해 작동)와 유지보수(관심사 분리) 고려해 별도 서비스로 분리

Closed #183 