### PR TITLE
[Refactor/Mod] schedule 수정 메서드 리팩토링 및 영속성 컨텍스트 충돌 문제 해결

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleAddDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleAddDto.java
@@ -1,5 +1,8 @@
 package devkor.ontime_back.dto;
 
+import devkor.ontime_back.entity.Place;
+import devkor.ontime_back.entity.Schedule;
+import devkor.ontime_back.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,22 +17,29 @@ import java.util.UUID;
 @AllArgsConstructor
 public class ScheduleAddDto {
     private UUID scheduleId;
-
     private UUID placeId;
-
     private String placeName;
-
     private String scheduleName;
-
     private Integer moveTime; // 이동시간
-
     private LocalDateTime scheduleTime; // 약속시각
-
     private Boolean isChange; // 변경여부
-
     private Boolean isStarted; // 버튼누름여부
-
     private Integer scheduleSpareTime; // 스케줄 별 여유시간
-
     private String scheduleNote; // 스케줄 별 주의사항
+
+    public Schedule toEntity(User user, Place place) {
+        return Schedule.builder()
+                .user(user)
+                .scheduleId(this.scheduleId)
+                .place(place)
+                .scheduleName(this.scheduleName)
+                .moveTime(this.moveTime)
+                .scheduleTime(this.scheduleTime)
+                .isChange(false)
+                .isStarted(false)
+                .scheduleSpareTime(this.scheduleSpareTime)
+                .latenessTime(-1)
+                .scheduleNote(this.scheduleNote)
+                .build();
+    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/entity/Schedule.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/Schedule.java
@@ -1,5 +1,6 @@
 package devkor.ontime_back.entity;
 
+import devkor.ontime_back.dto.ScheduleModDto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -54,14 +55,14 @@ public class Schedule {
     @Column(columnDefinition = "TEXT") // 명시적으로 TEXT 타입으로 정의
     private String scheduleNote; // 스케줄 별 주의사항
 
-    public void updateSchedule(Place place, String scheduleName, Integer moveTime, LocalDateTime scheduleTime, Integer scheduleSpareTime, Integer latenessTime, String scheduleNote) {
+    public void updateSchedule(Place place, ScheduleModDto scheduleModDto) {
         this.place = place;
-        this.scheduleName = scheduleName;
-        this.moveTime = moveTime;
-        this.scheduleTime = scheduleTime;
-        this.scheduleSpareTime = scheduleSpareTime;
-        this.latenessTime = latenessTime;
-        this.scheduleNote = scheduleNote;
+        this.scheduleName = scheduleModDto.getScheduleName();
+        this.moveTime = scheduleModDto.getMoveTime();
+        this.scheduleTime = scheduleModDto.getScheduleTime();
+        this.scheduleSpareTime = scheduleModDto.getScheduleSpareTime();
+        this.latenessTime = scheduleModDto.getLatenessTime();
+        this.scheduleNote = scheduleModDto.getScheduleNote();
     }
 
     public void startSchedule() {

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -87,8 +87,6 @@ public class ScheduleService {
 
         cancelAndDeleteNotification(notification);
         notificationScheduleRepository.flush();
-        preparationScheduleRepository.deleteBySchedule(schedule);
-        preparationScheduleRepository.flush();
         scheduleRepository.deleteByScheduleId(scheduleId);
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/ScheduleService.java
@@ -1,10 +1,7 @@
 package devkor.ontime_back.service;
 
 import devkor.ontime_back.dto.*;
-import devkor.ontime_back.entity.NotificationSchedule;
-import devkor.ontime_back.entity.Place;
-import devkor.ontime_back.entity.Schedule;
-import devkor.ontime_back.entity.User;
+import devkor.ontime_back.entity.*;
 import devkor.ontime_back.repository.*;
 import devkor.ontime_back.response.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -88,13 +85,14 @@ public class ScheduleService {
         NotificationSchedule notification = notificationScheduleRepository.findByScheduleScheduleId(scheduleId)
                 .orElseThrow(() -> new GeneralException(NOTIFICATION_NOT_FOUND));
 
-        cancleAndDeleteNotification(notification);
+        cancelAndDeleteNotification(notification);
         notificationScheduleRepository.flush();
         preparationScheduleRepository.deleteBySchedule(schedule);
+        preparationScheduleRepository.flush();
         scheduleRepository.deleteByScheduleId(scheduleId);
     }
 
-    private void cancleAndDeleteNotification(NotificationSchedule notification) {
+    private void cancelAndDeleteNotification(NotificationSchedule notification) {
         log.info("{}에 대한 알림 취소 및 삭제 됨", notification.getSchedule().getScheduleName());
         notification.disconnectSchedule();
         notificationService.cancelScheduledNotification(notification.getId());
@@ -110,14 +108,8 @@ public class ScheduleService {
         Place place = placeRepository.findByPlaceName(scheduleModDto.getPlaceName())
                 .orElseGet(() -> placeRepository.save(new Place(scheduleModDto.getPlaceId(), scheduleModDto.getPlaceName())));
 
-        schedule.updateSchedule(
-                place,
-                scheduleModDto.getScheduleName(),
-                scheduleModDto.getMoveTime(),
-                scheduleModDto.getScheduleTime(),
-                scheduleModDto.getScheduleSpareTime(),
-                scheduleModDto.getLatenessTime(),
-                scheduleModDto.getScheduleNote());
+        schedule.updateSchedule(place, scheduleModDto);
+
         scheduleRepository.save(schedule);
 
 
@@ -146,19 +138,7 @@ public class ScheduleService {
         Place place = placeRepository.findByPlaceName(scheduleAddDto.getPlaceName())
                 .orElseGet(() -> placeRepository.save(new Place(scheduleAddDto.getPlaceId(), scheduleAddDto.getPlaceName())));
 
-        Schedule schedule = Schedule.builder()
-                .scheduleId(scheduleAddDto.getScheduleId())
-                .user(user)
-                .place(place)
-                .scheduleName(scheduleAddDto.getScheduleName())
-                .moveTime(scheduleAddDto.getMoveTime())
-                .scheduleTime(scheduleAddDto.getScheduleTime())
-                .scheduleSpareTime(scheduleAddDto.getScheduleSpareTime())
-                .scheduleNote(scheduleAddDto.getScheduleNote())
-                .isChange(false)
-                .isStarted(false)
-                .latenessTime(-1)
-                .build();
+        Schedule schedule = scheduleAddDto.toEntity(user, place);
         scheduleRepository.save(schedule);
 
         NotificationSchedule notification = NotificationSchedule.builder()


### PR DESCRIPTION
### 문제 상황
```
2025-05-02T20:27:23.753+09:00 ERROR 1 --- [ontime-back] [nio-8080-exec-5] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.springframework.orm.ObjectOptimisticLockingFailureException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [devkor.ontime_back.entity.PreparationSchedule#123e4567-e89b-12d3-a456-326614174011]] with root cause

org.hibernate.StaleObjectStateException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [devkor.ontime_back.entity.PreparationSchedule#123e4567-e89b-12d3-a456-326614174011]
```
### 수정한 부분
- modifySchedule: Schedule 객체 내부에 updateSchedule 메서드에서 dto를 받아옴 -> 캡슐화 향상
- createSchedule: ScheduleAddDto에서 toEntity를 사용해서 Schedule 객체 생성
  - DTO → Entity 변환 책임을 DTO에 위임 (책임 분리) 
- `ObjectOptimisticLockingFailureException` 발생
  - preparationSchedule이랑 schedule이 연결되어있어서 preparationSchedule을 삭제하고 schedule을 삭제하는데, PreparationSchedule을 삭제했지만, Hibernate는 아직도 내부적으로 해당 엔티티들을 영속성 컨텍스트에 들고 있어서 마지막 flush() 시점(= 트랜잭션 커밋 직전)에 이미 삭제된 row에 대해 또 삭제 시도 → 충돌 발생
  - 해결방법) flush() 호출하여 영속성 컨텍스트에서 해당 엔티티들도 “삭제됨”으로 인식하게 됨

