### PR TITLE
[Feat] User 테이블에 엑세스토큰 저장하게하여 다중로그인 방지 (임시처리)

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
@@ -48,6 +48,8 @@ public class User {
 
     private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
 
+    private String accessToken; // accessToken
+
     private String refreshToken; // refreshToken
 
     private String firebaseToken;
@@ -125,5 +127,9 @@ public class User {
 
     public void updateFirebaseToken(String firebaseToken) {
         this.firebaseToken = firebaseToken;
+    }
+
+    public void updateAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
@@ -39,7 +39,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                     // 수정된 부분: 응답 헤더에 AccessToken, RefreshToken 실어서 응답
                     jwtTokenProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
 
-                    // 수정된 부분: RefreshToken을 User 엔티티에 업데이트 후 저장
+                    user.updateAccessToken(accessToken);
                     user.updateRefreshToken(refreshToken);
                     userRepository.saveAndFlush(user);
 

--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
@@ -166,6 +166,8 @@ public class JwtTokenProvider {
 
     public boolean isAccessTokenValid(String token) {
         try {
+            userRepository.findByAccessToken(token)
+                    .orElseThrow(() -> new InvalidAccessTokenException("유효하지 않은 엑세스 토큰입니다."));
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
             log.info("유효한 엑세스 토큰입니다.");
             return true;

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/UserRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/UserRepository.java
@@ -23,4 +23,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.spareTime FROM User u WHERE u.id = :id")
     Integer findSpareTimeById(Long id);
+
+    Optional<Object> findByAccessToken(String token);
 }

--- a/ontime-back/src/main/resources/db/migration/V4__add_field_accesstoken_to_user.sql
+++ b/ontime-back/src/main/resources/db/migration/V4__add_field_accesstoken_to_user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user ADD COLUMN access_token VARCHAR(255);


### PR DESCRIPTION
## 변경사항
- User 테이블에 access_token 필드 추가
- 로그인 시 User 테이블의 access_token필드에 엑세스토큰 저장
- 이후 권한이 필요한 요청시 엑세스토큰 검사할 때 DB의 엑세스 토큰과 대조

## 확인해야할 사항
- 이렇게하면 다중로그인은 방지가 됩니다.
- 다만, jwt가 가지는 이점이 사라진다는 치명적인 단점이 있습니다. jwt의 본질은 서버의 부하를 줄여준다는 점인데 권한이 필요한 매 요청마다 DB를 확인해야해 부담이 있긴합니다. 따라서 레디스에 로그인 정보를 저장을 하는 등의 방식으로 jwt의 이점을 살리면서 다중로그인을 방지할 수도 있습니다
- 제가 일정에 여유가 없어 우선은 임시방편으로 엑세스토큰 디비에 저장하는 방식으로 수정하였지만, 출시 전에 레디스로 바꾸거나 다른 방안을 찾아봐야 할 것 같습니다.