### PR TITLE
[Fix] 준비과정 중복 생성 에러 해결

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
@@ -32,4 +32,6 @@ public interface PreparationUserRepository extends JpaRepository<PreparationUser
     @Modifying
     @Query("UPDATE PreparationUser p SET p.nextPreparation = NULL WHERE p.user.id = :userId")
     void clearNextPreparationByUserId(@Param("userId") Long userId);
+
+    boolean existsByUser(User user);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     FIREBASE(1011, "FIREBASE로 메세지를 발송하였으나 오류가 발생했습니다.(유효하지 않은 토큰 등)", HttpStatus.BAD_REQUEST),
     FIRST_PREPARATION_NOT_FOUND(1012, "해당 ID의 사용자의 준비과정을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOTIFICATION_NOT_FOUND(1013, "알림을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST ),
+    PREPARATION_ALREADY_EXISTS(1014, "해당 사용자의 준비과정이 이미 존재합니다.", HttpStatus.BAD_REQUEST),
 
     // 공통 오류 메시지
     UNEXPECTED_ERROR(1000, "Unexpected Error: An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR),;

--- a/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
@@ -33,6 +33,10 @@ public class PreparationUserService {
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new GeneralException(USER_NOT_FOUND)
         );
+        boolean exists = preparationUserRepository.existsByUser(user);
+        if (exists) {
+            throw new GeneralException(PREPARATION_ALREADY_EXISTS);
+        }
         handlePreparationUsers(user, preparationDtoList, false);
 
     }


### PR DESCRIPTION
### 문제상황
- `/users/me/onboarding` 진행시, `user`의 준비과정이 중복되어서 생성되어 `preparation_user`를 조회할때 여러 개가 검색되는 문제가 생김

### 수정사항
- 생성 전에 해당 `user`의 준비과정이 존재하는지 확인하고, 존재하는 경우에는 `PREPARATION_ALREADY_EXISTS` 에러 발생시킴