### PR TITLE
[Mod] preparationUser 수정 로직 수정

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
@@ -34,6 +34,4 @@ public interface PreparationUserRepository extends JpaRepository<PreparationUser
     void clearNextPreparationByUserId(@Param("userId") Long userId);
 
     boolean existsByUser(User user);
-
-    List<PreparationUser> findByUser(User user);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/repository/PreparationUserRepository.java
@@ -34,4 +34,6 @@ public interface PreparationUserRepository extends JpaRepository<PreparationUser
     void clearNextPreparationByUserId(@Param("userId") Long userId);
 
     boolean existsByUser(User user);
+
+    List<PreparationUser> findByUser(User user);
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/service/PreparationUserService.java
@@ -78,6 +78,7 @@ public class PreparationUserService {
     protected void handlePreparationUsers(User user, List<PreparationDto> preparationDtoList, boolean shouldDeleteExisting) {
         if (shouldDeleteExisting) {
             preparationUserRepository.deleteByUser(user);
+            preparationUserRepository.flush();
         }
 
         Map<UUID, PreparationUser> preparationMap = new HashMap<>();
@@ -97,6 +98,7 @@ public class PreparationUserService {
                 .collect(Collectors.toList());
 
         preparationUserRepository.saveAll(preparationUsers);
+        preparationUserRepository.flush();
 
         preparationDtoList.stream()
                 .filter(dto -> dto.getNextPreparationId() != null)


### PR DESCRIPTION
### 문제사항
DB/캐시 상태와 관계 매핑 시점이 안 맞아서 Hibernate가 없는 엔티티를 참조하려고 함
1. 삭제 후 같은 UUID 재사용
	- deleteByUser(user)로 기존 엔티티를 삭제 -> 같은 UUID를 가진 새로운 PreparationUser를 saveAll()로 다시 생성하려고 함
	- Hibernate는 이 UUID를 이미 삭제된(removed) 엔티티로 기억 중이라 충돌 발생
2. flush 타이밍 문제
    - saveAll(preparationUsers) → DB에 insert 요청은 날렸지만 아직 트랜잭션 commit 전이라 DB에 반영되지 않은 상태
    - 그 직후 updateNextPreparation(nextPreparation)에서 nextPreparation을 참조하면 Hibernate가 조회하다가 못 찾음

### 수정사항
해결책:
1. 삭제 후에는 꼭 flush() 해서 캐시와 DB를 싱크
2. 새로 insert한 뒤에도 flush() 해서 DB에 반영된 상태에서 관계를 연결