### PR TITLE
[codex] Prepare EC2 backend deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,10 @@ jobs:
       - name: Prepare deploy files
         env:
           SPRING_APPLICATION_NAME: ${{ secrets.SPRING_APPLICATION_NAME }}
+          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
           SPRING_DATASOURCE_USERNAME: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
           SPRING_DATASOURCE_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
           SPRING_DATASOURCE_DRIVER_CLASS_NAME: ${{ secrets.SPRING_DATASOURCE_DRIVER_CLASS_NAME }}
-          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           SPRING_JPA_DATABASE_PLATFORM: ${{ secrets.SPRING_JPA_DATABASE_PLATFORM }}
           SPRING_JPA_HIBERNATE_DDL_AUTO: ${{ secrets.SPRING_JPA_HIBERNATE_DDL_AUTO }}
           JWT_SECRETKEY: ${{ secrets.JWT_SECRETKEY }}
@@ -65,13 +64,12 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           FEATURE_APPLE_LOGIN_ENABLED: ${{ secrets.FEATURE_APPLE_LOGIN_ENABLED }}
           AUTHKEY_743M7R5W3W: ${{ secrets.AUTHKEY_743M7R5W3W }}
+          SPRING_FLYWAY_URL: ${{ secrets.SPRING_FLYWAY_URL }}
+          SPRING_FLYWAY_USER: ${{ secrets.SPRING_FLYWAY_USER }}
+          SPRING_FLYWAY_PASSWORD: ${{ secrets.SPRING_FLYWAY_PASSWORD }}
           ONTIME_PUSH_FIREBASE_ADMINSDK: ${{ secrets.ONTIME_PUSH_FIREBASE_ADMINSDK }}
         run: |
           mkdir -p config secrets
-
-          mysql_database="${MYSQL_DATABASE:-ontime}"
-          mysql_root_password="${MYSQL_ROOT_PASSWORD:-$SPRING_DATASOURCE_PASSWORD}"
-          mysql_url="jdbc:mysql://mysql:3306/${mysql_database}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true"
 
           add_property() {
             printf '%s=%s\n' "$1" "$2" >> config/application.properties
@@ -79,7 +77,7 @@ jobs:
 
           : > config/application.properties
           add_property "spring.application.name" "$SPRING_APPLICATION_NAME"
-          add_property "spring.datasource.url" "$mysql_url"
+          add_property "spring.datasource.url" "$SPRING_DATASOURCE_URL"
           add_property "spring.datasource.username" "$SPRING_DATASOURCE_USERNAME"
           add_property "spring.datasource.password" "$SPRING_DATASOURCE_PASSWORD"
           add_property "spring.datasource.driver-class-name" "$SPRING_DATASOURCE_DRIVER_CLASS_NAME"
@@ -117,21 +115,14 @@ jobs:
           add_property "apple.team.id" "$APPLE_TEAM_ID"
           add_property "feature.apple-login.enabled" "${FEATURE_APPLE_LOGIN_ENABLED:-true}"
           add_property "spring.flyway.enabled" "true"
-          add_property "spring.flyway.url" "$mysql_url"
-          add_property "spring.flyway.user" "$SPRING_DATASOURCE_USERNAME"
-          add_property "spring.flyway.password" "$SPRING_DATASOURCE_PASSWORD"
+          add_property "spring.flyway.url" "$SPRING_FLYWAY_URL"
+          add_property "spring.flyway.user" "$SPRING_FLYWAY_USER"
+          add_property "spring.flyway.password" "$SPRING_FLYWAY_PASSWORD"
           add_property "spring.flyway.baseline-on-migrate" "true"
           add_property "management.endpoints.web.exposure.include" "health"
           add_property "management.endpoint.health.show-details" "always"
           add_property "server.forward-headers-strategy" "framework"
           add_property "firebase.service-account.path" "/app/secrets/firebase-adminsdk.json"
-
-          {
-            printf 'MYSQL_DATABASE=%s\n' "$mysql_database"
-            printf 'MYSQL_USER=%s\n' "$SPRING_DATASOURCE_USERNAME"
-            printf 'MYSQL_PASSWORD=%s\n' "$SPRING_DATASOURCE_PASSWORD"
-            printf 'MYSQL_ROOT_PASSWORD=%s\n' "$mysql_root_password"
-          } > config/mysql.env
 
           printf '%s' "$ONTIME_PUSH_FIREBASE_ADMINSDK" > secrets/firebase-adminsdk.json
           printf '%s' "$AUTHKEY_743M7R5W3W" > secrets/AuthKey_743M7R5W3W.p8
@@ -145,7 +136,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "project.jar,Dockerfile,docker-compose.yml,config/application.properties,config/mysql.env,secrets/firebase-adminsdk.json,secrets/AuthKey_743M7R5W3W.p8"
+          source: "project.jar,Dockerfile,docker-compose.yml,config/application.properties,secrets/firebase-adminsdk.json,secrets/AuthKey_743M7R5W3W.p8"
           target: "/home/ubuntu/OnTime-back"
 
       - name: Restart service on EC2

--- a/ontime-back/docker-compose.yml
+++ b/ontime-back/docker-compose.yml
@@ -1,21 +1,4 @@
 services:
-  mysql:
-    image: mysql:8.0
-    container_name: ontime-mysql
-    restart: unless-stopped
-    env_file:
-      - ./config/mysql.env
-    command:
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
-    volumes:
-      - mysql-data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-
   backend:
     build:
       context: .
@@ -23,16 +6,9 @@ services:
     image: ontime-backend
     container_name: ontime-backend
     restart: unless-stopped
-    depends_on:
-      mysql:
-        condition: service_healthy
     ports:
       - "8080:8080"
     volumes:
       - ./config/application.properties:/app/config/application.properties:ro
       - ./secrets/firebase-adminsdk.json:/app/secrets/firebase-adminsdk.json:ro
       - ./secrets/AuthKey_743M7R5W3W.p8:/app/secrets/AuthKey_743M7R5W3W.p8:ro
-
-volumes:
-  mysql-data:
-    name: ontime-mysql-data

--- a/ontime-back/docker-compose.yml
+++ b/ontime-back/docker-compose.yml
@@ -35,3 +35,4 @@ services:
 
 volumes:
   mysql-data:
+    name: ontime-mysql-data

--- a/ontime-back/docs/deployment/ec2.md
+++ b/ontime-back/docs/deployment/ec2.md
@@ -56,6 +56,8 @@ The deploy workflow writes these files under `/home/ubuntu/OnTime-back`:
 - `secrets/firebase-adminsdk.json`
 - `secrets/AuthKey_743M7R5W3W.p8`
 
-MySQL data is stored in the Docker volume `mysql-data`. Removing that volume deletes the deployed database.
+MySQL data is stored in the Docker volume `ontime-mysql-data`. Normal deploys run `docker compose down` without `-v`, so this volume is preserved across backend redeploys. Removing that volume deletes the deployed database.
+
+Keep `SPRING_JPA_HIBERNATE_DDL_AUTO` set to `validate` or another non-destructive value for production. Values such as `create` or `create-drop` can recreate schema and destroy data.
 
 Do not commit local `application.properties`, Firebase service account JSON, Apple `.p8` keys, or `.env` files.

--- a/ontime-back/docs/deployment/ec2.md
+++ b/ontime-back/docs/deployment/ec2.md
@@ -8,7 +8,7 @@ This service deploys to Amazon EC2 through `.github/workflows/deploy.yml`.
 2. Add the required GitHub Actions secrets listed below.
 3. Run the `Deploy` workflow manually from GitHub Actions, or push to the `deploy` branch.
 
-The workflow builds the Spring Boot jar, creates deploy-only config files from GitHub Secrets, uploads them to `/home/ubuntu/OnTime-back`, and restarts Docker Compose on the EC2 instance. Docker Compose runs both the backend and a private MySQL 8 container on the same Docker network.
+The workflow builds the Spring Boot jar, creates deploy-only config files from GitHub Secrets, uploads them to `/home/ubuntu/OnTime-back`, and restarts Docker Compose on the EC2 instance.
 
 ## Required EC2 Secrets
 
@@ -19,11 +19,11 @@ The workflow builds the Spring Boot jar, creates deploy-only config files from G
 ## Required Application Secrets
 
 - `SPRING_APPLICATION_NAME`
+- `SPRING_DATASOURCE_URL`
 - `SPRING_DATASOURCE_USERNAME`
 - `SPRING_DATASOURCE_PASSWORD`
 - `SPRING_DATASOURCE_DRIVER_CLASS_NAME`
 - `SPRING_JPA_HIBERNATE_DDL_AUTO`
-- `MYSQL_ROOT_PASSWORD`
 - `JWT_SECRETKEY`
 - `JWT_ACCESS_EXPIRATION`
 - `JWT_REFRESH_EXPIRATION`
@@ -35,12 +35,14 @@ The workflow builds the Spring Boot jar, creates deploy-only config files from G
 - `APPLE_LOGIN_KEY`
 - `APPLE_TEAM_ID`
 - `AUTHKEY_743M7R5W3W`
+- `SPRING_FLYWAY_URL`
+- `SPRING_FLYWAY_USER`
+- `SPRING_FLYWAY_PASSWORD`
 - `ONTIME_PUSH_FIREBASE_ADMINSDK`
 
 ## Optional Secrets
 
 - `SPRING_JPA_DATABASE_PLATFORM` defaults to `org.hibernate.dialect.MySQL8Dialect`.
-- `MYSQL_DATABASE` defaults to `ontime`.
 - `FEATURE_APPLE_LOGIN_ENABLED` defaults to `true`.
 - Google and Kakao OAuth provider/registration secrets are included by the workflow when configured.
 
@@ -52,12 +54,7 @@ The deploy workflow writes these files under `/home/ubuntu/OnTime-back`:
 - `Dockerfile`
 - `docker-compose.yml`
 - `config/application.properties`
-- `config/mysql.env`
 - `secrets/firebase-adminsdk.json`
 - `secrets/AuthKey_743M7R5W3W.p8`
-
-MySQL data is stored in the Docker volume `ontime-mysql-data`. Normal deploys run `docker compose down` without `-v`, so this volume is preserved across backend redeploys. Removing that volume deletes the deployed database.
-
-Keep `SPRING_JPA_HIBERNATE_DDL_AUTO` set to `validate` or another non-destructive value for production. Values such as `create` or `create-drop` can recreate schema and destroy data.
 
 Do not commit local `application.properties`, Firebase service account JSON, Apple `.p8` keys, or `.env` files.


### PR DESCRIPTION
## Summary

- Prepare EC2 deployment for the Spring backend container.
- Generate deploy-only runtime config and secret files from GitHub Secrets.
- Mount Firebase and Apple secret files at runtime instead of packaging them into the jar.
- Keep the database external through `SPRING_DATASOURCE_URL` and Flyway DB secrets.
- Move deployment docs under `ontime-back/docs/deployment/ec2.md`.

## Deploy behavior

This PR targets `deploy`. After it is merged, the push to `deploy` should trigger the `Deploy` workflow.

## Validation

- `./gradlew build -x test`
- `docker compose config`
- YAML parse check for `.github/workflows/deploy.yml`
