### PR TITLE
[codex] Fix social login token storage

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/entity/User.java
@@ -56,6 +56,8 @@ public class User {
 
     private String firebaseToken;
 
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String socialLoginToken;
 
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "user", cascade = CascadeType.ALL)

--- a/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
@@ -4,7 +4,6 @@ import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.persister.entity.EntityNameUse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -44,7 +43,6 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                     userRepository.saveAndFlush(user);
 
                     log.info("로그인에 성공하였습니다. 이메일 : {}", email);
-                    log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
                     log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
 
 

--- a/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/service/LoginService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/service/LoginService.java
@@ -18,8 +18,6 @@ public class LoginService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 이메일이 존재하지 않습니다."));
-        
-        System.out.println("유저임다: "+user);
 
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail())

--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
@@ -79,7 +79,7 @@ public class JwtTokenProvider {
         response.setStatus(HttpServletResponse.SC_OK);
 
         response.setHeader(accessHeader, accessToken);
-        log.info("발급된 Access Token : {}", accessToken);
+        log.info("Access Token 헤더 설정 완료");
     }
 
     // accessToken + refreshToken header에 넣어서 전송
@@ -88,7 +88,6 @@ public class JwtTokenProvider {
 
         setAccessTokenHeader(response, accessToken);
         setRefreshTokenHeader(response, refreshToken);
-        log.info("accesstoken: " + accessToken + "refreshtoken" + refreshToken);
         log.info("Access Token, Refresh Token 헤더 설정 완료");
     }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginService.java
@@ -194,7 +194,6 @@ public class AppleLoginService {
         String clientSecret = generateClientSecret();
         log.info("getAppleAccessTokenAndRefreshToken");
         log.info("client_id: {}", clientId);
-        log.info("client_secret: {}", clientSecret);
         MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
         requestBody.add("grant_type", "authorization_code");
         requestBody.add("code", authCode);

--- a/ontime-back/src/main/resources/db/migration/V9__change_field_social_login_token_longtext.sql
+++ b/ontime-back/src/main/resources/db/migration/V9__change_field_social_login_token_longtext.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `user`
+  MODIFY COLUMN `social_login_token` LONGTEXT NULL;


### PR DESCRIPTION
## What changed

- Added a Flyway migration to widen `user.social_login_token` to `LONGTEXT`.
- Updated the `User.socialLoginToken` JPA mapping to match the migrated schema.
- Removed logs that exposed access tokens, refresh tokens, and Apple client secrets.

## Why

Google and Apple OAuth refresh tokens can exceed 255 characters. The existing `VARCHAR(255)` column caused Google login to fail with `Data truncation: Data too long for column 'social_login_token'` when saving a user during login.

## Impact

OAuth login can persist provider refresh tokens without truncation errors. Production logs will also stop emitting raw credential material on login/token issuance paths.

## Validation

- `./gradlew compileJava` passes.
- `./gradlew test` compiles but cannot complete locally because the Spring test context attempts to connect to MySQL at `localhost:3306`, which is not running in this workspace.
