### PR TITLE
[codex] Fix Firebase initialization lifecycle hook

### DIFF
--- a/ontime-back/src/main/java/devkor/ontime_back/config/FirebaseInitialization.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/config/FirebaseInitialization.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -31,6 +31,9 @@ public class FirebaseInitialization {
 
             if (FirebaseApp.getApps().isEmpty()) {
                 FirebaseApp.initializeApp(options);
+                log.info("Firebase initialized successfully");
+            } else {
+                log.info("Firebase already initialized");
             }
         } catch (IOException e) {
             log.error("Failed to initialize Firebase", e);


### PR DESCRIPTION
## What changed

- Switched Firebase initialization from `javax.annotation.PostConstruct` to `jakarta.annotation.PostConstruct`.
- Added startup logs for successful/already-present Firebase initialization.

## Why

The production container has the Firebase service account mounted correctly and `firebase.service-account.path` configured, but scheduled push notifications fail with:

```text
FirebaseApp with name [DEFAULT] doesn't exist.
```

This indicates the initializer method is not being invoked before `FirebaseMessaging.getInstance()` is used. On Spring Boot 3 / Spring 6, lifecycle annotations should use the Jakarta namespace.

## Impact

The default Firebase app should be initialized during Spring startup, allowing scheduled Firebase push notifications to send normally.

## Validation

- `./gradlew compileJava` passes.

## Post-deploy check

Look for this line in container startup logs:

```text
Firebase initialized successfully
```
