### PR TITLE
[codex] Remove sensitive request logging

### DIFF
--- a/ontime-back/docs/logging-redaction-policy.md
+++ b/ontime-back/docs/logging-redaction-policy.md
@@ -1,0 +1,40 @@
+# Logging Redaction Policy
+
+Production logs must only contain operational metadata needed to debug routing,
+ownership, status, and latency. Request payloads are not safe log data.
+
+## Request Logs
+
+Controller request logging is centralized in `LoggingAspect` and
+`RequestLogPolicy`. Request logs must include only:
+
+- request ID
+- route
+- method
+- actor identifier
+- client IP
+- response status
+- timing in milliseconds
+
+The request logger must not inspect or render `@RequestBody` arguments.
+
+## Sensitive Fields
+
+Never log values or raw key/value payloads for credentials, OAuth material,
+profile text, notes, or request bodies. Sensitive key names include:
+
+- `authorization`
+- `firebaseToken`
+- `password`
+- `secret`
+- `token`
+
+When field-level logging is genuinely needed, add the field to
+`RequestLogPolicy`'s allowlist and keep the log statement metadata-only.
+
+## Regression Guard
+
+`SensitiveLoggingPolicyTest` scans application source for sensitive key names in
+logger calls, request-body logging in `LoggingAspect`, and DTO-generated
+`toString` methods. Any future exception must update this policy and the
+central allowlist in the same change.

--- a/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/LoggingAspect.java
@@ -2,33 +2,22 @@ package devkor.ontime_back;
 
 import devkor.ontime_back.dto.RequestInfoDto;
 import devkor.ontime_back.entity.ApiLog;
-import devkor.ontime_back.repository.ApiLogRepository;
+import devkor.ontime_back.logging.RequestLogPolicy;
 import devkor.ontime_back.response.GeneralException;
 import devkor.ontime_back.service.ApiLogService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-
-import java.lang.annotation.Annotation;
-import java.util.Map;
-
 
 @Slf4j
 @Aspect
@@ -37,95 +26,47 @@ import java.util.Map;
 public class LoggingAspect {
 
     private final ApiLogService apiLogService;
-    private static final String NO_PARAMS = "No Params";
-    private static final String NO_BODY = "No Body";
 
     @Pointcut("bean(*Controller)")
     private void allRequest() {}
 
     @Around("allRequest()")
     public Object logRequest(ProceedingJoinPoint joinPoint) throws Throwable {
-        RequestInfoDto requestInfoDto = extractRequestInfo();
-
-        // requestTime
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        HttpServletRequest request = attributes.getRequest();
+        String requestId = RequestLogPolicy.resolveRequestId(request);
+        RequestLogPolicy.exposeRequestId(attributes, requestId);
+        RequestInfoDto requestInfoDto = extractRequestInfo(request);
         long beforeRequest = System.currentTimeMillis();
 
-        // pathVariable, requestBody
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Object[] args = joinPoint.getArgs();
-        Annotation[][] parameterAnnotations = signature.getMethod().getParameterAnnotations();
-
-        String pathVariable = null;
-        String requestBody = null;
-
-        for (int i = 0; i < parameterAnnotations.length; i++) {
-            Annotation[] annotations = parameterAnnotations[i];
-            for (Annotation annotation : annotations) {
-                if (annotation instanceof PathVariable) {
-                    pathVariable = args[i].toString(); // @PathVariable 값 저장
-                } else if (annotation instanceof RequestBody) {
-                    requestBody = args[i].toString(); // @RequestBody 값 저장
-                }
-            }
-        }
-
-        // responseStatus
-        int responseStatus = 200;
-        Object result;
         try {
-            // 실제 메서드 실행
-            result = joinPoint.proceed();
+            Object result = joinPoint.proceed();
+            int responseStatus = 200;
             if (result instanceof ResponseEntity) {
                 ResponseEntity<?> responseEntity = (ResponseEntity<?>) result;
-                responseStatus = responseEntity.getStatusCodeValue(); // 상태 코드 추출
+                responseStatus = responseEntity.getStatusCode().value();
             }
 
-            // 정상 요청 로그 저장
             long timeTaken = System.currentTimeMillis() - beforeRequest;
-
-            ApiLog apiLog = buildApiLog(requestInfoDto, responseStatus, timeTaken);
-            apiLogService.saveLog(apiLog);
-
-            log.info("[Request Log] requestUrl: {}, requestMethod: {}, userId: {}, clientIp: {}, pathVariable: {}, requestBody: {}, responseStatus: {}, timeTaken: {}",
-                    requestInfoDto.getRequestUrl(), requestInfoDto.getRequestMethod(), requestInfoDto.getUserId(), requestInfoDto.getClientIp(),
-                    pathVariable != null ? pathVariable : NO_PARAMS,
-                    requestBody != null ? requestBody : NO_BODY,
-                    responseStatus, timeTaken);
+            saveApiLog(requestInfoDto, responseStatus, timeTaken);
+            log.info("[Request Log] requestId: {}, route: {}, method: {}, actor: {}, clientIp: {}, responseStatus: {}, timeTakenMs: {}",
+                    requestId, requestInfoDto.getRequestUrl(), requestInfoDto.getRequestMethod(), requestInfoDto.getUserId(),
+                    requestInfoDto.getClientIp(), responseStatus, timeTaken);
 
             return result;
-
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
+            int responseStatus = mapExceptionToStatusCode(ex);
+            long timeTaken = System.currentTimeMillis() - beforeRequest;
+            saveApiLog(requestInfoDto, responseStatus, timeTaken);
+            log.error("[Error Log] requestId: {}, route: {}, method: {}, actor: {}, clientIp: {}, exception: {}, responseStatus: {}, timeTakenMs: {}",
+                    requestId, requestInfoDto.getRequestUrl(), requestInfoDto.getRequestMethod(), requestInfoDto.getUserId(),
+                    requestInfoDto.getClientIp(), ex.getClass().getSimpleName(), responseStatus, timeTaken);
             throw ex;
         }
     }
 
-    @AfterThrowing(pointcut = "allRequest()", throwing = "ex")
-    public void logException(JoinPoint joinPoint, Exception ex) {
-        RequestInfoDto requestInfoDto = extractRequestInfo();
-
-        // exceptionName
-        String exceptionName;
-        if (ex instanceof GeneralException) {
-            exceptionName = ((GeneralException) ex).getErrorCode().name();
-        } else {
-            exceptionName = ex.getClass().getSimpleName();
-        };
-        // exceptionMessage
-        String exceptionMessage = ex.getMessage();
-        // responseStatus
-        int responseStatus = mapExceptionToStatusCode(ex);
-
-        log.error("[Error Log] requestUrl: {}, requestMethod: {}, userId: {}, clientIp: {}, exception: {}, message: {}, responseStatus: {}",
-                requestInfoDto.getRequestUrl(), requestInfoDto.getRequestMethod(), requestInfoDto.getUserId(), requestInfoDto.getClientIp(), exceptionName, exceptionMessage, responseStatus);
-
-        ApiLog errorLog = buildApiLog(requestInfoDto, responseStatus, 0);
-        apiLogService.saveLog(errorLog);
-    }
-
     // requestinfo 추출
-    private RequestInfoDto extractRequestInfo() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-
+    private RequestInfoDto extractRequestInfo(HttpServletRequest request) {
         String requestUrl = request.getRequestURI();
         String requestMethod = request.getMethod();
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -135,6 +76,11 @@ public class LoggingAspect {
         String clientIp = request.getRemoteAddr();
 
         return new RequestInfoDto(requestUrl, requestMethod, userId, clientIp);
+    }
+
+    private void saveApiLog(RequestInfoDto requestInfoDto, int responseStatus, long timeTaken) {
+        ApiLog apiLog = buildApiLog(requestInfoDto, responseStatus, timeTaken);
+        apiLogService.saveLog(apiLog);
     }
 
     // apilog 생성
@@ -149,7 +95,7 @@ public class LoggingAspect {
                 .build();
     }
 
-    private int mapExceptionToStatusCode(Exception e) {
+    private int mapExceptionToStatusCode(Throwable e) {
         if (e instanceof GeneralException ge) {
             return ge.getErrorCode().getCode();
         }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmDeviceCurrentRequestDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmDeviceCurrentRequestDto.java
@@ -4,11 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class AlarmDeviceCurrentRequestDto {

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmDeviceCurrentResponseDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmDeviceCurrentResponseDto.java
@@ -3,7 +3,6 @@ package devkor.ontime_back.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.Instant;
 
 @Getter

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmDeviceUnregisterRequestDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmDeviceUnregisterRequestDto.java
@@ -4,11 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class AlarmDeviceUnregisterRequestDto {

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmSettingsResponseDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmSettingsResponseDto.java
@@ -3,7 +3,6 @@ package devkor.ontime_back.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.Instant;
 
 @Getter

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmStatusCurrentResponseDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmStatusCurrentResponseDto.java
@@ -3,7 +3,6 @@ package devkor.ontime_back.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmStatusFailureDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmStatusFailureDto.java
@@ -4,11 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class AlarmStatusFailureDto {

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmStatusReportRequestDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmStatusReportRequestDto.java
@@ -4,15 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
-
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
 @Builder
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class AlarmStatusReportRequestDto {

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmWindowScheduleDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AlarmWindowScheduleDto.java
@@ -4,7 +4,6 @@ import devkor.ontime_back.entity.DoneStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/AppleTokenResponseDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/AppleTokenResponseDto.java
@@ -7,17 +7,12 @@ import lombok.Getter;
 public class AppleTokenResponseDto {
     @JsonProperty("access_token")
     private String accessToken;
-
     @JsonProperty("token_type")
     private String tokenType;
-
     @JsonProperty("expires_in")
     private long expiresIn;
-
     @JsonProperty("refresh_token")
     private String refreshToken;
-
     @JsonProperty("id_token")
     private String idToken;
-
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/ChangePasswordDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/ChangePasswordDto.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 public class ChangePasswordDto {
     private String currentPassword;
     private String newPassword;
-
     @Builder
     public ChangePasswordDto(String currentPassword, String newPassword) {
         this.currentPassword = currentPassword;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/FeedbackAddDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/FeedbackAddDto.java
@@ -1,11 +1,8 @@
 package devkor.ontime_back.dto;
 
 import lombok.Getter;
-import lombok.ToString;
-
 import java.util.UUID;
 
-@ToString
 @Getter
 public class FeedbackAddDto {
     private UUID feedbackId;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/FinishPreparationDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/FinishPreparationDto.java
@@ -2,16 +2,12 @@ package devkor.ontime_back.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
-
 import java.util.UUID;
 
-@ToString
 @Getter
 public class FinishPreparationDto {
     private UUID scheduleId;
     private Integer latenessTime;
-
     @Builder
     public FinishPreparationDto(UUID scheduleId, Integer latenessTime) {
         this.scheduleId = scheduleId;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/FirebaseTokenAddDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/FirebaseTokenAddDto.java
@@ -1,9 +1,7 @@
 package devkor.ontime_back.dto;
 
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class FirebaseTokenAddDto {
     String firebaseToken;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/FriendDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/FriendDto.java
@@ -2,16 +2,13 @@ package devkor.ontime_back.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 @Builder
 public class FriendDto {
     private Long friendId;
     private String friendName;
     private String friendEmail;
-
     public FriendDto(Long friendId, String friendName, String friendEmail) {
         this.friendId = friendId;
         this.friendName = friendName;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/GetFriendListResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/GetFriendListResponse.java
@@ -2,13 +2,10 @@ package devkor.ontime_back.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-
 import java.util.List;
 
 @Getter
 @Builder
 public class GetFriendListResponse {
-
     private List<FriendDto> friendsList;
-
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/GetFriendshipRequesterResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/GetFriendshipRequesterResponse.java
@@ -2,15 +2,12 @@ package devkor.ontime_back.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class GetFriendshipRequesterResponse {
     private Long requesterId;
     private String requesterName;
     private String requesterEmail;
-
     @Builder
     public GetFriendshipRequesterResponse(Long requesterId, String requesterName, String requesterEmail) {
         this.requesterId = requesterId;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/LatenessHistoryResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/LatenessHistoryResponse.java
@@ -1,19 +1,15 @@
 package devkor.ontime_back.dto;
 
 import lombok.Getter;
-import lombok.ToString;
-
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@ToString
 @Getter
 public class LatenessHistoryResponse {
     private UUID scheduleId;
     private String scheduleName;
     private LocalDateTime scheduleTime;
     private int latenessTime;
-
     public LatenessHistoryResponse(UUID scheduleId, String scheduleName, LocalDateTime scheduleTime, int latenessTime) {
         this.scheduleId = scheduleId;
         this.scheduleName = scheduleName;
@@ -21,4 +17,3 @@ public class LatenessHistoryResponse {
         this.latenessTime = latenessTime;
     }
 }
-

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleUserDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthAppleUserDto.java
@@ -7,7 +7,6 @@ public class OAuthAppleUserDto {
     private String appleUserId;
     private String email;
     private String fullName;
-
     public OAuthAppleUserDto(String appleUserId, String email, String fullName) {
         this.appleUserId = appleUserId;
         this.email = email;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthGoogleUserDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthGoogleUserDto.java
@@ -4,12 +4,10 @@ import lombok.Getter;
 
 @Getter
 public class OAuthGoogleUserDto {
-
     private String id;           // 고유 사용자 ID
     private String name;          // 사용자 이름
     private String picture;       // 프로필 이미지 URL
     private String email;         // 이메일
-
     public OAuthGoogleUserDto(String id, String name, String picture, String email) {
         this.id = id;
         this.name = name;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthKakaoUserDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/OAuthKakaoUserDto.java
@@ -7,7 +7,6 @@ import lombok.Data;
 public class OAuthKakaoUserDto {
     private String id;
     private Profile profile;
-
     @Data
     public static class Profile {
         private String nickname;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/PlaceDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/PlaceDto.java
@@ -3,7 +3,6 @@ package devkor.ontime_back.dto;
 import devkor.ontime_back.entity.Place;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
 import java.util.UUID;
 
 @Getter
@@ -11,7 +10,6 @@ import java.util.UUID;
 public class PlaceDto {
     private UUID placeId;
     private String placeName;
-
     public static PlaceDto fromEntity(Place place) {
         return new PlaceDto(place.getPlaceId(), place.getPlaceName());
     }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/PreparationDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/PreparationDto.java
@@ -3,8 +3,6 @@ package devkor.ontime_back.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.sql.Time;
 import java.util.UUID;
 
 @AllArgsConstructor
@@ -12,20 +10,7 @@ import java.util.UUID;
 @Builder
 public class PreparationDto {
     private UUID preparationId;
-
     private String preparationName;
-
     private Integer preparationTime;
-
     private UUID nextPreparationId;
-
-    @Override
-    public String toString() {
-        return "PreparationDto{" +
-                "preparationId=" + preparationId +
-                ", preparationName='" + preparationName + '\'' +
-                ", preparationTime=" + preparationTime +
-                ", nextPreparationId=" + nextPreparationId +
-                '}';
-    }
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/PunctualityScoreResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/PunctualityScoreResponse.java
@@ -2,9 +2,7 @@ package devkor.ontime_back.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @AllArgsConstructor
 @Getter
 public class PunctualityScoreResponse {

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/RequestInfoDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/RequestInfoDto.java
@@ -1,6 +1,5 @@
 package devkor.ontime_back.dto;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleAddDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleAddDto.java
@@ -7,12 +7,9 @@ import devkor.ontime_back.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
-
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@ToString
 @Getter
 @Builder
 @AllArgsConstructor
@@ -27,7 +24,6 @@ public class ScheduleAddDto {
     private Boolean isStarted; // 버튼누름여부
     private Integer scheduleSpareTime; // 스케줄 별 여유시간
     private String scheduleNote; // 스케줄 별 주의사항
-
     public Schedule toEntity(User user, Place place) {
         return Schedule.builder()
                 .user(user)

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleDto.java
@@ -5,12 +5,10 @@ import devkor.ontime_back.entity.Place;
 import devkor.ontime_back.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.sql.Time;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@ToString
 @Data
 @NoArgsConstructor // 기본 생성자 추가
 @AllArgsConstructor // 모든 필드를 포함하는 생성자 추가
@@ -24,5 +22,4 @@ public class ScheduleDto {
     private String scheduleNote;
     private Integer latenessTime;
     private DoneStatus doneStatus;
-
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleModDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/ScheduleModDto.java
@@ -3,31 +3,19 @@ package devkor.ontime_back.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
-
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@ToString
 @Getter
 @Builder
 @AllArgsConstructor
 public class ScheduleModDto {
-
     private UUID placeId;
-
     private String placeName;
-
     private String scheduleName;
-
     private Integer moveTime; // 이동시간
-
     private LocalDateTime scheduleTime; // 약속시각
-
     private Integer scheduleSpareTime; // 스케줄 별 여유시간
-
     private Integer latenessTime;
-
     private String scheduleNote; // 스케줄 별 주의사항
-
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/SchedulePeriodDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/SchedulePeriodDto.java
@@ -1,11 +1,8 @@
 package devkor.ontime_back.dto;
 
 import lombok.Getter;
-import lombok.ToString;
-
 import java.time.LocalDateTime;
 
-@ToString
 @Getter
 public class SchedulePeriodDto {
     LocalDateTime startDate;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateAcceptStatusDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateAcceptStatusDto.java
@@ -1,9 +1,7 @@
 package devkor.ontime_back.dto;
 
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class UpdateAcceptStatusDto {
     private String acceptStatus;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UpdatePunctualityScoreDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UpdatePunctualityScoreDto.java
@@ -1,9 +1,7 @@
 package devkor.ontime_back.dto;
 
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class UpdatePunctualityScoreDto {
     private Long userId;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateSpareTimeDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UpdateSpareTimeDto.java
@@ -3,14 +3,11 @@ package devkor.ontime_back.dto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-@ToString
 @Getter
 @NoArgsConstructor
 public class UpdateSpareTimeDto {
     private Integer newSpareTime;
-
     @Builder
     public UpdateSpareTimeDto(Integer newSpareTime) {
         this.newSpareTime = newSpareTime;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserAdditionalInfoDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserAdditionalInfoDto.java
@@ -1,15 +1,12 @@
 package devkor.ontime_back.dto;
 
 import lombok.*;
-
 import java.sql.Time;
 
-@ToString
 @Getter
 public class UserAdditionalInfoDto {
     private Integer spareTime;  // 여유시간
     private String note;     // 주의사항
-
     @Builder
     public UserAdditionalInfoDto(Integer spareTime, String note) {
         this.spareTime = spareTime;

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserInfoResponse.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserInfoResponse.java
@@ -5,9 +5,7 @@ import devkor.ontime_back.entity.SocialType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @AllArgsConstructor
 @Getter
 @Builder

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserOnboardingDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserOnboardingDto.java
@@ -2,7 +2,6 @@ package devkor.ontime_back.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-
 import java.util.List;
 
 @Getter
@@ -11,5 +10,4 @@ public class UserOnboardingDto {
     private Integer spareTime;
     private String note;
     private List<PreparationDto> preparationList;
-
 }

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserSettingUpdateDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserSettingUpdateDto.java
@@ -2,9 +2,7 @@ package devkor.ontime_back.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-@ToString
 @Getter
 @NoArgsConstructor
 public class UserSettingUpdateDto {

--- a/ontime-back/src/main/java/devkor/ontime_back/dto/UserSignUpDto.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/dto/UserSignUpDto.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.util.UUID;
 
 @NoArgsConstructor

--- a/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/generallogin/handler/LoginSuccessHandler.java
@@ -4,8 +4,6 @@ import devkor.ontime_back.global.jwt.JwtTokenProvider;
 import devkor.ontime_back.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.persister.entity.EntityNameUse;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -21,9 +19,6 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
-
-    @Value("${jwt.access.expiration}")
-    private String accessTokenExpiration;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -43,9 +38,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                     user.updateRefreshToken(refreshToken);
                     userRepository.saveAndFlush(user);
 
-                    log.info("로그인에 성공하였습니다. 이메일 : {}", email);
-                    log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
-                    log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
+                    log.info("Login succeeded for userId: {}", user.getId());
 
 
                     try {

--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtAuthenticationFilter.java
@@ -60,7 +60,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 // 리프레시토큰의 경우 토큰의 유효성 뿐만 아니라 DB에 등록되어 있는지도 확인해야 함
                 // reIssueAccessToken 메소드에서 DB를 확인해 등록된 리프레시 토큰이면 엑세스 토큰 재발급
                 // 이때 reIssueAccessToken 메소드에서 DB에 등록된 리프레시 토큰이 아니면 InvalidRefreshTokenException 발생
-                log.info("리프레시 토큰이 있고 유효한데 DB에 있는지는 아직 모름");
+                log.info("Refresh credential passed signature validation; checking stored credential");
                 reIssueAccessToken(response, refreshToken);
                 return;
             }
@@ -90,10 +90,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // 리프레시 토큰이 DB에 있으면 엑세스 토큰을 재발급
     // DB에 없으면 InvalidRefreshTokenException 발생
     public void reIssueAccessToken(HttpServletResponse response, String refreshToken) throws IOException {
-        log.info("리프레시토큰이 유효하나 DB에 있는지는 모름. DB에서 찾아봐서 없으면 예외 발생할 것임.");
+        log.info("Checking stored refresh credential");
         User user = userRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new InvalidRefreshTokenException("Invalid Refresh token!~!"));
-        log.info("리프레시토큰이 DB에도 있음");
+        log.info("Stored refresh credential matched");
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getId());
 
@@ -105,7 +105,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // accessToken으로 유저의 권한정보만 저장하고 인증 허가(스프링 시큐리티 필터체인 中 인증체인 통과해 다음 체인으로 이동)
     public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
                                                   FilterChain filterChain) throws ServletException, IOException {
-        log.info("checkAccessTokenAndAuthentication() 호출");
+        log.info("Checking access credential authentication");
         jwtTokenProvider.extractAccessToken(request)
                 .ifPresent(accessToken -> {
                     jwtTokenProvider.extractEmail(accessToken)
@@ -114,7 +114,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                             );
 
                     jwtTokenProvider.extractUserId(accessToken)
-                            .ifPresent(userId -> log.info("추출된 userId: {}", userId));
+                            .ifPresent(userId -> log.info("Authenticated userId: {}", userId));
                 });
 
         filterChain.doFilter(request, response);
@@ -158,7 +158,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-        log.info("InvalidTokenException 발생");
+        log.info("Credential validation exception occurred");
 
         // ErrorCode에서 정보를 가져옴
         ErrorCode errorCode = ErrorCode.UNAUTHORIZED;

--- a/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/jwt/JwtTokenProvider.java
@@ -55,7 +55,6 @@ public class JwtTokenProvider {
     // accessToken 생성
     public String createAccessToken(String email, Long userId) {
         Date now = new Date();
-        log.info("expiresAt: {}", new Date(now.getTime() + accessTokenExpirationPeriod));
         return JWT.create()
                 .withSubject(ACCESS_TOKEN_SUBJECT)
                 .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
@@ -79,7 +78,6 @@ public class JwtTokenProvider {
         response.setStatus(HttpServletResponse.SC_OK);
 
         response.setHeader(accessHeader, accessToken);
-        log.info("발급된 Access Token : {}", accessToken);
     }
 
     // accessToken + refreshToken header에 넣어서 전송
@@ -88,8 +86,7 @@ public class JwtTokenProvider {
 
         setAccessTokenHeader(response, accessToken);
         setRefreshTokenHeader(response, refreshToken);
-        log.info("accesstoken: " + accessToken + "refreshtoken" + refreshToken);
-        log.info("Access Token, Refresh Token 헤더 설정 완료");
+        log.info("Credential headers set");
     }
 
     // header에서 refreshToken 추출
@@ -115,7 +112,7 @@ public class JwtTokenProvider {
                     .getClaim(EMAIL_CLAIM)
                     .asString());
         } catch (Exception e) {
-            log.error("액세스 토큰이 유효하지 않습니다.as");
+            log.error("Access credential is invalid");
             return Optional.empty();
         }
     }
@@ -129,7 +126,7 @@ public class JwtTokenProvider {
                     .getClaim(USER_ID_CLAIM)
                     .asLong());
         } catch (Exception e) {
-            log.error("유효하지 않은 accessToken입니다.");
+            log.error("Access credential is invalid");
             return Optional.empty();
         }
     }
@@ -158,10 +155,10 @@ public class JwtTokenProvider {
     public boolean isTokenValid(String token) {
         try {
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
-            log.info("유효한 토큰입니다.");
+            log.info("Credential is valid");
             return true;
         } catch (Exception e) {
-            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            log.error("Credential is invalid");
             throw new InvalidTokenException("유효하지 않은 토큰입니다.");
         }
     }
@@ -171,10 +168,10 @@ public class JwtTokenProvider {
             userRepository.findByAccessToken(token)
                     .orElseThrow(() -> new InvalidAccessTokenException("유효하지 않은 엑세스 토큰입니다."));
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
-            log.info("유효한 엑세스 토큰입니다.");
+            log.info("Access credential is valid");
             return true;
         } catch (Exception e) {
-            log.error("유효하지 않은 엑세스 토큰입니다. {}", e.getMessage());
+            log.error("Access credential is invalid");
             throw new InvalidAccessTokenException("유효하지 않은 엑세스 토큰입니다.");
         }
     }
@@ -182,10 +179,10 @@ public class JwtTokenProvider {
     public boolean isRefreshTokenValid(String token) {
         try {
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
-            log.info("유효한 리프레시 토큰입니다.");
+            log.info("Refresh credential is valid");
             return true;
         } catch (Exception e) {
-            log.error("유효하지 않은 리프레시 토큰입니다. {}", e.getMessage());
+            log.error("Refresh credential is invalid");
             throw new InvalidRefreshTokenException("유효하지 않은 리프레시 토큰입니다.");
         }
     }

--- a/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginFilter.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginFilter.java
@@ -69,7 +69,6 @@ public class AppleLoginFilter extends AbstractAuthenticationProcessingFilter {
             }
 
             String appleUserId = tokenClaims.getSubject();
-            log.info("appleUserId: {}", appleUserId);
             String email = tokenClaims.get("email", String.class);
 
             // socialRefreshtoken에 저장
@@ -86,10 +85,9 @@ public class AppleLoginFilter extends AbstractAuthenticationProcessingFilter {
             }
 
         } catch (Exception e) {
-            log.error("Apple 로그인 실패: {}", e.getMessage(), e);
+            log.error("Apple login failed: {}", e.getClass().getSimpleName());
             throw new AuthenticationException("Apple 로그인 실패") {};
         }
     }
 
 }
-

--- a/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/oauth/apple/AppleLoginService.java
@@ -164,7 +164,7 @@ public class AppleLoginService {
     // identitytoken 검증
     public Claims verifyIdentityToken(String identityToken) throws
             Exception {
-        log.info("verifyIdentityToken");
+        log.info("Verify Apple identity credential");
         Map<String, String> headers = jwtUtils.parseHeaders(identityToken);
         // apple publickey
         ApplePublicKeyResponse applePublicKeyResponse = restTemplate.getForObject(APPLE_KEYS_URL, ApplePublicKeyResponse.class);
@@ -192,9 +192,7 @@ public class AppleLoginService {
     public AppleTokenResponseDto getAppleAccessTokenAndRefreshToken(String authCode) throws Exception {
         // clientSecret
         String clientSecret = generateClientSecret();
-        log.info("getAppleAccessTokenAndRefreshToken");
-        log.info("client_id: {}", clientId);
-        log.info("client_secret: {}", clientSecret);
+        log.info("Exchange Apple credential");
         MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
         requestBody.add("grant_type", "authorization_code");
         requestBody.add("code", authCode);
@@ -218,7 +216,7 @@ public class AppleLoginService {
 
     // clientsecret 생성
     private String generateClientSecret() throws Exception {
-        log.info("generageClientSecret");
+        log.info("Generate Apple client credential");
         // Private Key
         String privateKeyContent = new String(Files.readAllBytes(Paths.get(privateKeyPath)))
                 .replace("-----BEGIN PRIVATE KEY-----", "")

--- a/ontime-back/src/main/java/devkor/ontime_back/global/oauth/google/GoogleLoginFilter.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/oauth/google/GoogleLoginFilter.java
@@ -52,7 +52,7 @@ public class GoogleLoginFilter extends AbstractAuthenticationProcessingFilter {
             }
 
         } catch (Exception e) {
-            log.error("Google 로그인 실패: {}", e.getMessage(), e);
+            log.error("Google login failed: {}", e.getClass().getSimpleName());
             throw new AuthenticationException("Google 로그인 실패") {};
         }
 

--- a/ontime-back/src/main/java/devkor/ontime_back/global/oauth/google/GoogleLoginService.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/global/oauth/google/GoogleLoginService.java
@@ -164,7 +164,7 @@ public class GoogleLoginService {
             GoogleIdToken.Payload payload = idToken.getPayload();
             return payload;
         } else {
-            log.info("유효하지 않은 idtoken 입니다.");
+            log.info("Google identity credential is invalid");
             return null;
         }
     }

--- a/ontime-back/src/main/java/devkor/ontime_back/logging/RequestLogPolicy.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/logging/RequestLogPolicy.java
@@ -1,0 +1,81 @@
+package devkor.ontime_back.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+public final class RequestLogPolicy {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String REQUEST_ID_ATTRIBUTE = RequestLogPolicy.class.getName() + ".requestId";
+
+    private static final Pattern SAFE_REQUEST_ID = Pattern.compile("[A-Za-z0-9._:-]{1,128}");
+
+    private static final Set<String> SENSITIVE_FIELD_NAMES = Set.of(
+            "authorization",
+            "authCode",
+            "clientSecret",
+            "client_secret",
+            "currentPassword",
+            "firebaseToken",
+            "idToken",
+            "newPassword",
+            "password",
+            "refreshToken",
+            "secret",
+            "token"
+    );
+
+    private static final Set<String> SAFE_FIELD_ALLOWLIST = Set.of(
+            "appVersion",
+            "armedScheduleCount",
+            "clientIp",
+            "deviceId",
+            "method",
+            "osVersion",
+            "platform",
+            "requestId",
+            "responseStatus",
+            "route",
+            "timeTakenMs",
+            "userId"
+    );
+
+    private RequestLogPolicy() {
+    }
+
+    public static String resolveRequestId(HttpServletRequest request) {
+        Object existingRequestId = request.getAttribute(REQUEST_ID_ATTRIBUTE);
+        if (existingRequestId instanceof String existing && !existing.isBlank()) {
+            return existing;
+        }
+
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        if (requestId == null || !SAFE_REQUEST_ID.matcher(requestId).matches()) {
+            requestId = UUID.randomUUID().toString();
+        }
+
+        request.setAttribute(REQUEST_ID_ATTRIBUTE, requestId);
+        return requestId;
+    }
+
+    public static void exposeRequestId(ServletRequestAttributes attributes, String requestId) {
+        HttpServletResponse response = attributes.getResponse();
+        if (response != null) {
+            response.setHeader(REQUEST_ID_HEADER, requestId);
+        }
+    }
+
+    public static boolean isSafeFieldForLogging(String fieldName) {
+        return SAFE_FIELD_ALLOWLIST.contains(fieldName) && !isSensitiveFieldName(fieldName);
+    }
+
+    public static boolean isSensitiveFieldName(String fieldName) {
+        return SENSITIVE_FIELD_NAMES.stream()
+                .anyMatch(sensitiveField -> sensitiveField.equalsIgnoreCase(fieldName));
+    }
+}

--- a/ontime-back/src/main/java/devkor/ontime_back/response/GlobalExceptionHandler.java
+++ b/ontime-back/src/main/java/devkor/ontime_back/response/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package devkor.ontime_back.response;
 
+import devkor.ontime_back.logging.RequestLogPolicy;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -30,10 +31,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponseForm<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex, HttpServletRequest request) {
-        log.error("[Error Log] requestUrl: {}, requestMethod: {}, userId: {}, clientIp: {}, exception: {}, message: {}, responseStatus: {}",
-                request.getRequestURI(), request.getMethod(), (request.getUserPrincipal() != null) ? request.getUserPrincipal().getName() : "Anonymous", request.getRemoteAddr(), "HttpMessageNotReadableException", "요청 형식이 올바르지 않습니다.", 400);
+        String requestId = RequestLogPolicy.resolveRequestId(request);
+
+        log.error("[Error Log] requestId: {}, route: {}, method: {}, actor: {}, clientIp: {}, exception: {}, responseStatus: {}",
+                requestId, request.getRequestURI(), request.getMethod(), (request.getUserPrincipal() != null) ? request.getUserPrincipal().getName() : "Anonymous", request.getRemoteAddr(), "HttpMessageNotReadableException", 400);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
+                .header(RequestLogPolicy.REQUEST_ID_HEADER, requestId)
                 .body(ApiResponseForm.error(400, "요청 형식이 올바르지 않습니다."));
     }
 

--- a/ontime-back/src/test/java/devkor/ontime_back/security/SensitiveLoggingPolicyTest.java
+++ b/ontime-back/src/test/java/devkor/ontime_back/security/SensitiveLoggingPolicyTest.java
@@ -1,0 +1,97 @@
+package devkor.ontime_back.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SensitiveLoggingPolicyTest {
+
+    private static final Path MAIN_SOURCE_ROOT = Path.of("src/main/java");
+    private static final Pattern LOG_STATEMENT = Pattern.compile(
+            "log\\.(?:trace|debug|info|warn|error)\\s*\\((.*?)\\);",
+            Pattern.DOTALL
+    );
+    private static final List<String> SENSITIVE_LOG_TERMS = List.of(
+            "authorization",
+            "firebaseToken",
+            "password",
+            "secret",
+            "token"
+    );
+
+    @Test
+    void logStatementsDoNotReferenceSensitiveKeyNames() throws IOException {
+        try (Stream<Path> sourceFiles = Files.walk(MAIN_SOURCE_ROOT)) {
+            List<String> violations = sourceFiles
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .flatMap(this::findSensitiveLogStatements)
+                    .toList();
+
+            assertThat(violations)
+                    .as("Log statements must not reference sensitive key names or sensitive variables")
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void requestLoggingAspectDoesNotReadRequestBodies() throws IOException {
+        String loggingAspect = Files.readString(MAIN_SOURCE_ROOT.resolve("devkor/ontime_back/LoggingAspect.java"));
+
+        assertThat(loggingAspect)
+                .doesNotContain("org.springframework.web.bind.annotation.RequestBody")
+                .doesNotContain("requestBody")
+                .doesNotContain(".toString()");
+    }
+
+    @Test
+    void dtoPackageDoesNotGenerateStringRepresentations() throws IOException {
+        try (Stream<Path> dtoFiles = Files.walk(MAIN_SOURCE_ROOT.resolve("devkor/ontime_back/dto"))) {
+            List<String> violations = dtoFiles
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> {
+                        try {
+                            String source = Files.readString(path);
+                            return source.contains("@ToString") || source.contains("String toString()");
+                        } catch (IOException e) {
+                            throw new IllegalStateException(e);
+                        }
+                    })
+                    .map(Path::toString)
+                    .toList();
+
+            assertThat(violations)
+                    .as("DTOs should not auto-render sensitive request payloads")
+                    .isEmpty();
+        }
+    }
+
+    private Stream<String> findSensitiveLogStatements(Path sourceFile) {
+        try {
+            String source = Files.readString(sourceFile);
+            Matcher matcher = LOG_STATEMENT.matcher(source);
+            Stream.Builder<String> violations = Stream.builder();
+
+            while (matcher.find()) {
+                String statement = matcher.group(1);
+                String normalizedStatement = statement.toLowerCase(Locale.ROOT);
+                SENSITIVE_LOG_TERMS.stream()
+                        .filter(term -> normalizedStatement.contains(term.toLowerCase(Locale.ROOT)))
+                        .findFirst()
+                        .ifPresent(term -> violations.add(sourceFile + " logs sensitive term: " + term));
+            }
+
+            return violations.build();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace raw controller request logging with metadata-only logs and request IDs.
- Remove token, secret, OAuth credential, and sensitive exception-message logging.
- Remove DTO string rendering and add a documented logging redaction policy.
- Add a static regression test that fails on sensitive log terms, request-body logging, or DTO `toString` reintroduction.

## Validation
- `./gradlew test --tests devkor.ontime_back.security.SensitiveLoggingPolicyTest`
- `./gradlew test` compiles, then is blocked by local MySQL/Flyway connectivity (`CommunicationsException`) in this workspace.

Closes #274
