### PR TITLE
[codex] Use workflow token for dev GHCR pull

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -138,7 +138,7 @@ jobs:
             FIREBASE_CREDENTIALS_BASE64=${{ secrets.DEV_FIREBASE_CREDENTIALS_BASE64 }}
             EOF
 
-            echo "${{ secrets.GHCR_READ_TOKEN }}" | sudo docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
+            echo "${{ secrets.GITHUB_TOKEN }}" | sudo docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
             if sudo docker compose version >/dev/null 2>&1; then
               COMPOSE="sudo docker compose"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,8 +120,8 @@ Required development secrets:
 - `DEV_REMOTE_HOST`
 - `DEV_REMOTE_USER`
 - `DEV_REMOTE_SSH_KEY`
-- `GHCR_USERNAME`
-- `GHCR_READ_TOKEN`
+
+The development workflow uses the run-scoped `GITHUB_TOKEN` to pull the image from GHCR on the remote PC, so no long-lived GHCR read token is required for development deploys.
 
 Optional development secrets:
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -132,11 +132,9 @@ Development deploy should use development secrets only:
 DEV_REMOTE_HOST
 DEV_REMOTE_USER
 DEV_REMOTE_SSH_KEY
-GHCR_USERNAME
-GHCR_READ_TOKEN
 ```
 
-Optional `DEV_*` secrets can override the default dev deploy directory, HTTP port, MySQL credentials, and non-production OAuth/Firebase settings.
+The development deploy uses the workflow `GITHUB_TOKEN` for GHCR image pulls. Optional `DEV_*` secrets can override the default dev deploy directory, HTTP port, MySQL credentials, and non-production OAuth/Firebase settings.
 
 ## Branch Protection
 


### PR DESCRIPTION
## Summary
- use the workflow-scoped `GITHUB_TOKEN` for the remote PC GHCR login during dev deploy
- remove `GHCR_USERNAME`/`GHCR_READ_TOKEN` from development deploy requirements in docs

## Why
The remote PC login succeeded but `docker compose pull` returned `denied` for `ghcr.io/devkor-github/ontime-back`, which indicates the PAT used by `GHCR_READ_TOKEN` did not have package access for that image. The workflow token has package permissions for the image it just pushed, so it is the right token for this deploy pull.

## Validation
- parsed `.github/workflows/deploy-dev.yml` with Ruby YAML loader
- `docker compose -f docker-compose.yml -f docker-compose.dev.yml config`
